### PR TITLE
[style]theme: add dark brand token foundation

### DIFF
--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,48 +1,81 @@
 import { createTheme } from "@mui/material/styles";
 
+const brandTokens = {
+  background: "#080A0F",
+  surface: "#11151D",
+  surfaceRaised: "#171C26",
+  textPrimary: "#F6F7FB",
+  textSecondary: "#A8B0BF",
+  border: "rgba(166, 176, 195, 0.18)",
+  violet: "#9B7CFF",
+  violetDark: "#6F55D8",
+  violetSoft: "rgba(155, 124, 255, 0.14)",
+};
+
 export const theme = createTheme({
   palette: {
-    mode: "light",
+    mode: "dark",
     primary: {
-      main: "#005A9C",
+      main: brandTokens.violet,
+      dark: brandTokens.violetDark,
+      contrastText: "#080A0F",
     },
     secondary: {
-      main: "#A03A2A",
+      main: "#77E0C6",
+      contrastText: "#080A0F",
     },
     background: {
-      default: "#F6F8FB",
-      paper: "#FFFFFF",
+      default: brandTokens.background,
+      paper: brandTokens.surface,
     },
     text: {
-      primary: "#16202B",
-      secondary: "#304153",
+      primary: brandTokens.textPrimary,
+      secondary: brandTokens.textSecondary,
     },
+    divider: brandTokens.border,
   },
   shape: {
-    borderRadius: 12,
+    borderRadius: 8,
   },
   typography: {
     fontFamily: "var(--font-body), 'Segoe UI', sans-serif",
     h1: {
-      fontFamily: "var(--font-heading), Georgia, serif",
+      fontFamily: "var(--font-heading), 'Segoe UI', Arial, sans-serif",
       fontWeight: 700,
       fontSize: "clamp(2rem, 4vw, 3rem)",
       lineHeight: 1.15,
     },
     h2: {
-      fontFamily: "var(--font-heading), Georgia, serif",
+      fontFamily: "var(--font-heading), 'Segoe UI', Arial, sans-serif",
       fontWeight: 700,
       fontSize: "clamp(1.7rem, 3vw, 2.2rem)",
       lineHeight: 1.2,
     },
     h3: {
-      fontFamily: "var(--font-heading), Georgia, serif",
+      fontFamily: "var(--font-heading), 'Segoe UI', Arial, sans-serif",
       fontWeight: 700,
       fontSize: "clamp(1.4rem, 2.4vw, 1.8rem)",
       lineHeight: 1.3,
     },
+    h4: {
+      fontFamily: "var(--font-heading), 'Segoe UI', Arial, sans-serif",
+      fontWeight: 700,
+      lineHeight: 1.3,
+    },
   },
   components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: {
+          backgroundColor: brandTokens.background,
+          color: brandTokens.textPrimary,
+        },
+        "::selection": {
+          backgroundColor: brandTokens.violetSoft,
+          color: brandTokens.textPrimary,
+        },
+      },
+    },
     MuiButtonBase: {
       defaultProps: {
         disableRipple: false,
@@ -51,24 +84,89 @@ export const theme = createTheme({
     MuiButton: {
       styleOverrides: {
         root: {
+          borderRadius: 8,
           textTransform: "none",
           fontWeight: 600,
+          boxShadow: "none",
+          "&.Mui-focusVisible": {
+            boxShadow: `0 0 0 3px ${brandTokens.violetSoft}`,
+          },
+        },
+        contained: {
+          "&:hover": {
+            boxShadow: "none",
+          },
+        },
+        outlined: {
+          borderColor: brandTokens.border,
+          "&:hover": {
+            borderColor: brandTokens.violet,
+            backgroundColor: brandTokens.violetSoft,
+          },
+        },
+        text: {
+          "&:hover": {
+            backgroundColor: brandTokens.violetSoft,
+          },
         },
       },
     },
     MuiLink: {
       styleOverrides: {
         root: {
+          color: brandTokens.textPrimary,
           textUnderlineOffset: "0.18em",
           textDecorationThickness: "0.08em",
+          "&:hover": {
+            color: brandTokens.violet,
+          },
+          "&:focus-visible": {
+            borderRadius: 4,
+            outline: `2px solid ${brandTokens.violet}`,
+            outlineOffset: 3,
+          },
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: "none",
+          borderColor: brandTokens.border,
         },
       },
     },
     MuiCard: {
       styleOverrides: {
         root: {
-          border: "1px solid #D6DEE8",
-          boxShadow: "0 1px 2px rgba(16, 24, 40, 0.08)",
+          border: `1px solid ${brandTokens.border}`,
+          backgroundColor: brandTokens.surface,
+          boxShadow: "none",
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          borderColor: brandTokens.border,
+          backgroundColor: brandTokens.surfaceRaised,
+          color: brandTokens.textSecondary,
+          fontWeight: 600,
+        },
+        colorPrimary: {
+          backgroundColor: brandTokens.violetSoft,
+          color: brandTokens.textPrimary,
+        },
+        outlined: {
+          borderColor: brandTokens.border,
+        },
+      },
+    },
+    MuiDivider: {
+      styleOverrides: {
+        root: {
+          borderColor: brandTokens.border,
         },
       },
     },


### PR DESCRIPTION
## Summary
- Converts the MUI theme to a dark-first brand foundation.
- Adds near-black backgrounds, charcoal surfaces, off-white text, cool gray secondary text, muted borders, and restrained violet accents.
- Tightens shared component defaults for buttons, cards, chips, links, dividers, and focus styling while keeping MUI as the styling system.

## Validation
- npm run lint
- npm run format:check
- npm run build

## Visual Summary
Existing routes now inherit the dark theme tokens and reduced 8px surface radius. Global CSS and shell layout remain unchanged for the follow-up foundation issues.

Closes #4