### PR TITLE
[style]layout: update metadata and font direction

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Bitter, JetBrains_Mono, Source_Sans_3 } from "next/font/google";
+import { JetBrains_Mono, Source_Sans_3, Space_Grotesk } from "next/font/google";
 import "./globals.css";
 
 import { SiteShell } from "@/components/site-shell";
@@ -12,7 +12,7 @@ const sourceSans = Source_Sans_3({
   display: "swap",
 });
 
-const bitter = Bitter({
+const spaceGrotesk = Space_Grotesk({
   variable: "--font-heading",
   subsets: ["latin"],
   display: "swap",
@@ -50,7 +50,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${sourceSans.variable} ${bitter.variable} ${jetbrainsMono.variable}`}
+      className={`${sourceSans.variable} ${spaceGrotesk.variable} ${jetbrainsMono.variable}`}
     >
       <body>
         <ThemeRegistry>

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,8 +1,9 @@
 export const siteConfig = {
   ownerName: "Alex Lucero",
-  siteTitle: "Alex Lucero | Portfolio",
+  studioName: "Loose Arrow Labs",
+  siteTitle: "Alex Lucero | Loose Arrow Labs",
   siteDescription:
-    "Production-style personal website for Alex Lucero with project deep dives and resume content.",
+    "Founder-led technical portfolio for Alex Lucero, with Loose Arrow Labs as the studio identity for practical software, automation, and AI integration work.",
   email: "TODO_ADD_EMAIL",
   github: "TODO_ADD_GITHUB_URL",
   linkedin: "TODO_ADD_LINKEDIN_URL",


### PR DESCRIPTION
## Summary
- Replaces the serif heading font with Space Grotesk for a more geometric technical direction.
- Updates site metadata to keep Alex Lucero primary and Loose Arrow Labs as the secondary studio identity.
- Preserves the existing ThemeRegistry and App Router layout structure.

## Validation
- npm run lint
- npm run format:check
- npm run build

Closes #6