### PR TITLE
[refactor]shell: establish founder-led header and footer

### DIFF
--- a/src/components/site-shell.tsx
+++ b/src/components/site-shell.tsx
@@ -6,8 +6,9 @@ import { siteConfig } from "@/lib/site";
 
 const navigationLinks = [
   { href: "/", label: "Home" },
-  { href: "/resume", label: "Resume" },
   { href: "/projects", label: "Projects" },
+  { href: "/about", label: "About" },
+  { href: "/resume", label: "Resume" },
   { href: "/contact", label: "Contact" },
 ];
 
@@ -23,19 +24,29 @@ export function SiteShell({ children }: SiteShellProps) {
         sx={{
           borderBottom: "1px solid",
           borderColor: "divider",
-          backgroundColor: "rgba(255,255,255,0.8)",
+          backgroundColor: "rgba(8, 10, 15, 0.88)",
+          backdropFilter: "blur(16px)",
         }}
       >
         <Container maxWidth="lg">
           <Toolbar disableGutters sx={{ gap: 2, py: 1.5, flexWrap: "wrap" }}>
-            <Typography
+            <Stack
               component="a"
               href={toInternalHref("/")}
-              variant="h6"
+              spacing={0.25}
               sx={{ color: "text.primary", textDecoration: "none" }}
             >
-              {siteConfig.ownerName}
-            </Typography>
+              <Typography component="span" variant="h6" sx={{ lineHeight: 1.1 }}>
+                {siteConfig.ownerName}
+              </Typography>
+              <Typography
+                component="span"
+                variant="caption"
+                sx={{ color: "text.secondary", letterSpacing: 0, textTransform: "uppercase" }}
+              >
+                {siteConfig.studioName}
+              </Typography>
+            </Stack>
             <Stack
               component="nav"
               aria-label="Primary navigation"
@@ -64,9 +75,15 @@ export function SiteShell({ children }: SiteShellProps) {
 
       <Box component="footer" sx={{ borderTop: "1px solid", borderColor: "divider", py: 2.5 }}>
         <Container maxWidth="lg">
-          <Typography variant="body2" color="text.secondary">
-            {new Date().getFullYear()} {siteConfig.ownerName}
-          </Typography>
+          <Stack spacing={0.5}>
+            <Typography variant="body2" color="text.primary">
+              {new Date().getFullYear()} {siteConfig.ownerName}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {siteConfig.studioName} is the studio layer for selected software, automation, and AI
+              integration work.
+            </Typography>
+          </Stack>
         </Container>
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- Updates primary navigation to include Home, Projects, About, Resume, and Contact.
- Makes Alex Lucero the primary shell identity with Loose Arrow Labs as the supporting studio line.
- Refreshes header/footer treatment for the dark foundation without adding a new route implementation.

## Validation
- npm run lint
- npm run format:check
- npm run build

## Visual Summary
The shell now reads founder-first in the header and footer while preserving access to the existing routes. The About link is present for the planned route in a later issue.

Closes #7