### PR TITLE
[refactor]components: add foundational atoms

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,7 @@
-import { Box, Card, CardContent, Link, Stack, Typography } from "@mui/material";
+import { Box, Card, CardContent, Stack, Typography } from "@mui/material";
 import type { Metadata } from "next";
 
+import { ExternalLink, SectionHeading } from "@/components/atoms";
 import { getResume } from "@/lib/content";
 import { siteConfig } from "@/lib/site";
 
@@ -23,15 +24,15 @@ export default async function ContactPage() {
 
   return (
     <Stack spacing={3.5}>
-      <Typography component="h1" variant="h1">
+      <SectionHeading component="h1" variant="h1">
         Contact
-      </Typography>
+      </SectionHeading>
 
       <Card component="section" aria-labelledby="contact-links-heading">
         <CardContent>
-          <Typography id="contact-links-heading" component="h2" variant="h2" sx={{ mb: 2 }}>
+          <SectionHeading id="contact-links-heading" sx={{ mb: 2 }}>
             Reach Out
-          </Typography>
+          </SectionHeading>
 
           <Stack spacing={1.25}>
             <Typography component="p">
@@ -44,25 +45,13 @@ export default async function ContactPage() {
               <Box component="span" sx={{ fontWeight: 700 }}>
                 LinkedIn:{" "}
               </Box>
-              {isExternalLink(linkedin) ? (
-                <Link href={linkedin} target="_blank" rel="noopener noreferrer">
-                  {linkedin}
-                </Link>
-              ) : (
-                linkedin
-              )}
+              {isExternalLink(linkedin) ? <ExternalLink href={linkedin} /> : linkedin}
             </Typography>
             <Typography component="p">
               <Box component="span" sx={{ fontWeight: 700 }}>
                 GitHub:{" "}
               </Box>
-              {isExternalLink(github) ? (
-                <Link href={github} target="_blank" rel="noopener noreferrer">
-                  {github}
-                </Link>
-              ) : (
-                github
-              )}
+              {isExternalLink(github) ? <ExternalLink href={github} /> : github}
             </Typography>
           </Stack>
         </CardContent>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import {
   Card,
   CardActions,
   CardContent,
-  Chip,
   Divider,
   Grid,
   Stack,
@@ -13,6 +12,7 @@ import {
 } from "@mui/material";
 import type { Metadata } from "next";
 
+import { SectionEyebrow, SectionHeading, StatusChip, TechTag } from "@/components/atoms";
 import { MdxContent } from "@/components/mdx-content";
 import { getBio, getFeaturedProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
@@ -30,19 +30,22 @@ export default async function HomePage() {
   return (
     <Stack spacing={7}>
       <Box component="section" aria-labelledby="home-bio-heading">
-        <Typography id="home-bio-heading" component="h1" variant="h1" gutterBottom>
+        <SectionHeading id="home-bio-heading" component="h1" variant="h1" gutterBottom>
           {bio.frontmatter.title ?? "Alex Lucero"}
-        </Typography>
+        </SectionHeading>
         <MdxContent>{bio.content}</MdxContent>
+        <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ mt: 2 }}>
+          {["Next.js", "TypeScript", "MUI", "MDX"].map((tag) => (
+            <TechTag key={tag} label={tag} />
+          ))}
+        </Stack>
       </Box>
 
       <Divider />
 
       <Box component="section" aria-labelledby="featured-projects-heading">
         <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2.5 }}>
-          <Typography id="featured-projects-heading" component="h2" variant="h2">
-            Featured Projects
-          </Typography>
+          <SectionHeading id="featured-projects-heading">Featured Projects</SectionHeading>
           <Button href={toInternalHref("/projects")} variant="text" endIcon={<ArrowForward />}>
             All projects
           </Button>
@@ -58,7 +61,7 @@ export default async function HomePage() {
                   <Typography color="text.secondary" sx={{ mb: 2 }}>
                     {project.summary}
                   </Typography>
-                  {project.status ? <Chip size="small" label={project.status} /> : null}
+                  {project.status ? <StatusChip label={project.status} /> : null}
                 </CardContent>
                 <CardActions>
                   <Button
@@ -78,12 +81,10 @@ export default async function HomePage() {
       <Divider />
 
       <Box component="section" aria-labelledby="working-now-heading">
-        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
-          <Chip size="small" label="Now" color="primary" />
-          <Typography id="working-now-heading" component="h2" variant="h2">
-            What I&apos;m Working On
-          </Typography>
-        </Stack>
+        <SectionEyebrow>Now</SectionEyebrow>
+        <SectionHeading id="working-now-heading" sx={{ mb: 1.5 }}>
+          What I&apos;m Working On
+        </SectionHeading>
         <Typography component="p" color="text.secondary">
           {bio.frontmatter.now ??
             "TODO: Add current work focus in /content/bio.mdx frontmatter `now`."}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,16 +1,8 @@
 import { ArrowForward } from "@mui/icons-material";
-import {
-  Button,
-  Card,
-  CardActions,
-  CardContent,
-  Chip,
-  Grid,
-  Stack,
-  Typography,
-} from "@mui/material";
+import { Button, Card, CardActions, CardContent, Grid, Stack, Typography } from "@mui/material";
 import type { Metadata } from "next";
 
+import { MonoLabel, SectionHeading, StatusChip } from "@/components/atoms";
 import { getAllProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 
@@ -27,9 +19,9 @@ export default async function ProjectsPage() {
 
   return (
     <Stack spacing={3.5}>
-      <Typography component="h1" variant="h1">
+      <SectionHeading component="h1" variant="h1">
         Projects
-      </Typography>
+      </SectionHeading>
       <Grid container spacing={2.5}>
         {projects.map((project) => (
           <Grid key={project.slug} size={{ xs: 12, md: 6 }}>
@@ -42,12 +34,8 @@ export default async function ProjectsPage() {
                   {project.summary}
                 </Typography>
                 <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
-                  {project.status ? (
-                    <Chip size="small" label={project.status} color="primary" />
-                  ) : null}
-                  {project.updated ? (
-                    <Chip size="small" label={`Updated ${project.updated}`} />
-                  ) : null}
+                  {project.status ? <StatusChip label={project.status} /> : null}
+                  {project.updated ? <MonoLabel>Updated {project.updated}</MonoLabel> : null}
                 </Stack>
               </CardContent>
               <CardActions>

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,6 +1,7 @@
-import { Box, Button, Stack, Typography } from "@mui/material";
+import { Box, Button, Stack } from "@mui/material";
 import type { Metadata } from "next";
 
+import { SectionHeading } from "@/components/atoms";
 import { MdxContent } from "@/components/mdx-content";
 import { getResume } from "@/lib/content";
 
@@ -18,9 +19,9 @@ export default async function ResumePage() {
   return (
     <Stack spacing={3}>
       <Box component="header">
-        <Typography component="h1" variant="h1" gutterBottom>
+        <SectionHeading component="h1" variant="h1" gutterBottom>
           {resume.frontmatter.title ?? "Resume"}
-        </Typography>
+        </SectionHeading>
         <Button href={pdfPath} variant="contained" component="a" download>
           Download PDF
         </Button>

--- a/src/components/atoms/external-link.tsx
+++ b/src/components/atoms/external-link.tsx
@@ -1,0 +1,15 @@
+import { Link } from "@mui/material";
+import type { ReactNode } from "react";
+
+type ExternalLinkProps = {
+  children?: ReactNode;
+  href: string;
+};
+
+export function ExternalLink({ children, href }: ExternalLinkProps) {
+  return (
+    <Link href={href} target="_blank" rel="noopener noreferrer" sx={{ wordBreak: "break-word" }}>
+      {children ?? href}
+    </Link>
+  );
+}

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,0 +1,6 @@
+export { ExternalLink } from "./external-link";
+export { MonoLabel } from "./mono-label";
+export { SectionEyebrow } from "./section-eyebrow";
+export { SectionHeading } from "./section-heading";
+export { StatusChip } from "./status-chip";
+export { TechTag } from "./tech-tag";

--- a/src/components/atoms/mono-label.tsx
+++ b/src/components/atoms/mono-label.tsx
@@ -1,0 +1,24 @@
+import { Typography } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material/styles";
+import type { ReactNode } from "react";
+
+type MonoLabelProps = {
+  children: ReactNode;
+  sx?: SxProps<Theme>;
+};
+
+export function MonoLabel({ children, sx }: MonoLabelProps) {
+  return (
+    <Typography
+      component="span"
+      variant="caption"
+      sx={{
+        color: "text.secondary",
+        fontFamily: "var(--font-code), ui-monospace, SFMono-Regular, Menlo, monospace",
+        ...sx,
+      }}
+    >
+      {children}
+    </Typography>
+  );
+}

--- a/src/components/atoms/section-eyebrow.tsx
+++ b/src/components/atoms/section-eyebrow.tsx
@@ -1,0 +1,29 @@
+import { Typography } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material/styles";
+import type { ReactNode } from "react";
+
+type SectionEyebrowProps = {
+  children: ReactNode;
+  id?: string;
+  sx?: SxProps<Theme>;
+};
+
+export function SectionEyebrow({ children, id, sx }: SectionEyebrowProps) {
+  return (
+    <Typography
+      id={id}
+      component="p"
+      variant="overline"
+      sx={{
+        color: "primary.main",
+        display: "block",
+        fontWeight: 700,
+        letterSpacing: 0,
+        mb: 1,
+        ...sx,
+      }}
+    >
+      {children}
+    </Typography>
+  );
+}

--- a/src/components/atoms/section-heading.tsx
+++ b/src/components/atoms/section-heading.tsx
@@ -1,0 +1,27 @@
+import { Typography } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material/styles";
+import type { ReactNode } from "react";
+
+type SectionHeadingProps = {
+  children: ReactNode;
+  component?: "h1" | "h2" | "h3";
+  gutterBottom?: boolean;
+  id?: string;
+  sx?: SxProps<Theme>;
+  variant?: "h1" | "h2" | "h3";
+};
+
+export function SectionHeading({
+  children,
+  component = "h2",
+  gutterBottom,
+  id,
+  sx,
+  variant = "h2",
+}: SectionHeadingProps) {
+  return (
+    <Typography id={id} component={component} variant={variant} gutterBottom={gutterBottom} sx={sx}>
+      {children}
+    </Typography>
+  );
+}

--- a/src/components/atoms/status-chip.tsx
+++ b/src/components/atoms/status-chip.tsx
@@ -1,0 +1,9 @@
+import { Chip } from "@mui/material";
+
+type StatusChipProps = {
+  label: string;
+};
+
+export function StatusChip({ label }: StatusChipProps) {
+  return <Chip size="small" label={label} color="primary" />;
+}

--- a/src/components/atoms/tech-tag.tsx
+++ b/src/components/atoms/tech-tag.tsx
@@ -1,0 +1,9 @@
+import { Chip } from "@mui/material";
+
+type TechTagProps = {
+  label: string;
+};
+
+export function TechTag({ label }: TechTagProps) {
+  return <Chip size="small" label={label} variant="outlined" />;
+}


### PR DESCRIPTION
## Summary
- Adds the first practical atom layer: section eyebrow, section heading, status chip, tech tag, external link, and mono label.
- Wires every new atom into existing real pages in the same PR.
- Keeps the components MUI-based and avoids adding design-system tooling or unused inventory.

## Validation
- npm run lint
- npm run format:check
- npm run build

## Notes
TechTag is used only for true repo stack labels on the current home intro. Project tech metadata remains authored in MDX until a later scoped content-model issue.

Closes #8