### PR TITLE
[refactor]components: add shared content molecules

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,7 +1,8 @@
-import { Box, Card, CardContent, Stack, Typography } from "@mui/material";
+import { Card, CardContent, Stack } from "@mui/material";
 import type { Metadata } from "next";
 
-import { ExternalLink, SectionHeading } from "@/components/atoms";
+import { SectionHeading } from "@/components/atoms";
+import { ContactLinkList } from "@/components/molecules";
 import { getResume } from "@/lib/content";
 import { siteConfig } from "@/lib/site";
 
@@ -11,10 +12,6 @@ export const metadata: Metadata = {
   title: "Contact",
   description: "Contact details for Alex Lucero.",
 };
-
-function isExternalLink(value: string): boolean {
-  return value.startsWith("http://") || value.startsWith("https://");
-}
 
 export default async function ContactPage() {
   const resume = await getResume();
@@ -34,26 +31,13 @@ export default async function ContactPage() {
             Reach Out
           </SectionHeading>
 
-          <Stack spacing={1.25}>
-            <Typography component="p">
-              <Box component="span" sx={{ fontWeight: 700 }}>
-                Email:{" "}
-              </Box>
-              {email}
-            </Typography>
-            <Typography component="p">
-              <Box component="span" sx={{ fontWeight: 700 }}>
-                LinkedIn:{" "}
-              </Box>
-              {isExternalLink(linkedin) ? <ExternalLink href={linkedin} /> : linkedin}
-            </Typography>
-            <Typography component="p">
-              <Box component="span" sx={{ fontWeight: 700 }}>
-                GitHub:{" "}
-              </Box>
-              {isExternalLink(github) ? <ExternalLink href={github} /> : github}
-            </Typography>
-          </Stack>
+          <ContactLinkList
+            links={[
+              { label: "Email", value: email },
+              { label: "LinkedIn", value: linkedin },
+              { label: "GitHub", value: github },
+            ]}
+          />
         </CardContent>
       </Card>
     </Stack>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 import { ArrowForward } from "@mui/icons-material";
 import {
   Box,
-  Button,
   Card,
   CardActions,
   CardContent,
@@ -12,8 +11,9 @@ import {
 } from "@mui/material";
 import type { Metadata } from "next";
 
-import { SectionEyebrow, SectionHeading, StatusChip, TechTag } from "@/components/atoms";
+import { SectionEyebrow, SectionHeading, TechTag } from "@/components/atoms";
 import { MdxContent } from "@/components/mdx-content";
+import { CTAGroup, ProjectMetaRow } from "@/components/molecules";
 import { getBio, getFeaturedProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 
@@ -46,9 +46,15 @@ export default async function HomePage() {
       <Box component="section" aria-labelledby="featured-projects-heading">
         <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2.5 }}>
           <SectionHeading id="featured-projects-heading">Featured Projects</SectionHeading>
-          <Button href={toInternalHref("/projects")} variant="text" endIcon={<ArrowForward />}>
-            All projects
-          </Button>
+          <CTAGroup
+            actions={[
+              {
+                endIcon: <ArrowForward />,
+                href: toInternalHref("/projects"),
+                label: "All projects",
+              },
+            ]}
+          />
         </Stack>
         <Grid container spacing={2.5}>
           {featuredProjects.map((project) => (
@@ -61,16 +67,18 @@ export default async function HomePage() {
                   <Typography color="text.secondary" sx={{ mb: 2 }}>
                     {project.summary}
                   </Typography>
-                  {project.status ? <StatusChip label={project.status} /> : null}
+                  <ProjectMetaRow status={project.status} />
                 </CardContent>
                 <CardActions>
-                  <Button
-                    href={toInternalHref(`/projects/${project.slug}`)}
-                    size="small"
-                    endIcon={<ArrowForward />}
-                  >
-                    View details
-                  </Button>
+                  <CTAGroup
+                    actions={[
+                      {
+                        endIcon: <ArrowForward />,
+                        href: toInternalHref(`/projects/${project.slug}`),
+                        label: "View details",
+                      },
+                    ]}
+                  />
                 </CardActions>
               </Card>
             </Grid>

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,9 +1,11 @@
 import { ArrowBack } from "@mui/icons-material";
-import { Box, Button, Chip, Stack, Typography } from "@mui/material";
+import { Box, Stack } from "@mui/material";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import { SectionHeading } from "@/components/atoms";
 import { MdxContent } from "@/components/mdx-content";
+import { CTAGroup, ProjectMetaRow } from "@/components/molecules";
 import { getProjectBySlug, getProjectSlugs } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 
@@ -54,25 +56,21 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
   return (
     <Stack spacing={3.5}>
       <Box component="header">
-        <Button
-          href={toInternalHref("/projects")}
-          variant="text"
-          startIcon={<ArrowBack />}
-          sx={{ mb: 1.5 }}
-        >
-          Back to projects
-        </Button>
-        <Typography component="h1" variant="h1" gutterBottom>
+        <Box sx={{ mb: 1.5 }}>
+          <CTAGroup
+            actions={[
+              {
+                href: toInternalHref("/projects"),
+                label: "Back to projects",
+                startIcon: <ArrowBack />,
+              },
+            ]}
+          />
+        </Box>
+        <SectionHeading component="h1" variant="h1" gutterBottom>
           {project.frontmatter.title}
-        </Typography>
-        <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
-          {project.frontmatter.status ? (
-            <Chip size="small" label={project.frontmatter.status} color="primary" />
-          ) : null}
-          {project.frontmatter.updated ? (
-            <Chip size="small" label={`Updated ${project.frontmatter.updated}`} />
-          ) : null}
-        </Stack>
+        </SectionHeading>
+        <ProjectMetaRow status={project.frontmatter.status} updated={project.frontmatter.updated} />
       </Box>
 
       <MdxContent>{project.content}</MdxContent>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,8 +1,9 @@
 import { ArrowForward } from "@mui/icons-material";
-import { Button, Card, CardActions, CardContent, Grid, Stack, Typography } from "@mui/material";
+import { Card, CardActions, CardContent, Grid, Stack, Typography } from "@mui/material";
 import type { Metadata } from "next";
 
-import { MonoLabel, SectionHeading, StatusChip } from "@/components/atoms";
+import { SectionHeading } from "@/components/atoms";
+import { CTAGroup, ProjectMetaRow } from "@/components/molecules";
 import { getAllProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 
@@ -33,19 +34,18 @@ export default async function ProjectsPage() {
                 <Typography color="text.secondary" sx={{ mb: 2 }}>
                   {project.summary}
                 </Typography>
-                <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
-                  {project.status ? <StatusChip label={project.status} /> : null}
-                  {project.updated ? <MonoLabel>Updated {project.updated}</MonoLabel> : null}
-                </Stack>
+                <ProjectMetaRow status={project.status} updated={project.updated} />
               </CardContent>
               <CardActions>
-                <Button
-                  href={toInternalHref(`/projects/${project.slug}`)}
-                  size="small"
-                  endIcon={<ArrowForward />}
-                >
-                  Open project
-                </Button>
+                <CTAGroup
+                  actions={[
+                    {
+                      endIcon: <ArrowForward />,
+                      href: toInternalHref(`/projects/${project.slug}`),
+                      label: "Open project",
+                    },
+                  ]}
+                />
               </CardActions>
             </Card>
           </Grid>

--- a/src/components/molecules/activity-item.tsx
+++ b/src/components/molecules/activity-item.tsx
@@ -1,0 +1,26 @@
+import { Stack, Typography } from "@mui/material";
+
+import { ExternalLink, MonoLabel } from "@/components/atoms";
+
+type ActivityItemProps = {
+  href?: string;
+  label?: string;
+  summary?: string;
+  title: string;
+};
+
+export function ActivityItem({ href, label, summary, title }: ActivityItemProps) {
+  return (
+    <Stack spacing={0.5}>
+      {label ? <MonoLabel>{label}</MonoLabel> : null}
+      <Typography component="h3" variant="h3" sx={{ fontSize: "1.1rem" }}>
+        {href ? <ExternalLink href={href}>{title}</ExternalLink> : title}
+      </Typography>
+      {summary ? (
+        <Typography color="text.secondary" sx={{ maxWidth: "64ch" }}>
+          {summary}
+        </Typography>
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/components/molecules/contact-link-list.tsx
+++ b/src/components/molecules/contact-link-list.tsx
@@ -1,0 +1,37 @@
+import { Box, Stack, Typography } from "@mui/material";
+
+import { ExternalLink } from "@/components/atoms";
+
+type ContactLink = {
+  label: string;
+  value?: string;
+};
+
+type ContactLinkListProps = {
+  links: ContactLink[];
+};
+
+function isExternalLink(value: string): boolean {
+  return value.startsWith("http://") || value.startsWith("https://");
+}
+
+export function ContactLinkList({ links }: ContactLinkListProps) {
+  const visibleLinks = links.filter((link) => link.value);
+
+  if (visibleLinks.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack spacing={1.25}>
+      {visibleLinks.map((link) => (
+        <Typography key={link.label} component="p">
+          <Box component="span" sx={{ fontWeight: 700 }}>
+            {link.label}:{" "}
+          </Box>
+          {isExternalLink(link.value ?? "") ? <ExternalLink href={link.value ?? ""} /> : link.value}
+        </Typography>
+      ))}
+    </Stack>
+  );
+}

--- a/src/components/molecules/cta-group.tsx
+++ b/src/components/molecules/cta-group.tsx
@@ -1,0 +1,36 @@
+import { Button, Stack } from "@mui/material";
+import type { ReactNode } from "react";
+
+type CTA = {
+  endIcon?: ReactNode;
+  href: string;
+  label: string;
+  startIcon?: ReactNode;
+  variant?: "contained" | "outlined" | "text";
+};
+
+type CTAGroupProps = {
+  actions: CTA[];
+};
+
+export function CTAGroup({ actions }: CTAGroupProps) {
+  if (actions.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+      {actions.map((action) => (
+        <Button
+          key={`${action.href}-${action.label}`}
+          href={action.href}
+          variant={action.variant ?? "text"}
+          startIcon={action.startIcon}
+          endIcon={action.endIcon}
+        >
+          {action.label}
+        </Button>
+      ))}
+    </Stack>
+  );
+}

--- a/src/components/molecules/evidence-link-list.tsx
+++ b/src/components/molecules/evidence-link-list.tsx
@@ -1,0 +1,32 @@
+import { List, ListItem, ListItemText } from "@mui/material";
+
+import { ExternalLink } from "@/components/atoms";
+
+export type EvidenceLink = {
+  description?: string;
+  href: string;
+  label: string;
+};
+
+type EvidenceLinkListProps = {
+  links?: EvidenceLink[];
+};
+
+export function EvidenceLinkList({ links = [] }: EvidenceLinkListProps) {
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <List disablePadding>
+      {links.map((link) => (
+        <ListItem key={link.href} disableGutters>
+          <ListItemText
+            primary={<ExternalLink href={link.href}>{link.label}</ExternalLink>}
+            secondary={link.description}
+          />
+        </ListItem>
+      ))}
+    </List>
+  );
+}

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,0 +1,6 @@
+export { ActivityItem } from "./activity-item";
+export { ContactLinkList } from "./contact-link-list";
+export { CTAGroup } from "./cta-group";
+export { EvidenceLinkList } from "./evidence-link-list";
+export type { EvidenceLink } from "./evidence-link-list";
+export { ProjectMetaRow } from "./project-meta-row";

--- a/src/components/molecules/project-meta-row.tsx
+++ b/src/components/molecules/project-meta-row.tsx
@@ -1,0 +1,21 @@
+import { Stack } from "@mui/material";
+
+import { MonoLabel, StatusChip } from "@/components/atoms";
+
+type ProjectMetaRowProps = {
+  status?: string;
+  updated?: string;
+};
+
+export function ProjectMetaRow({ status, updated }: ProjectMetaRowProps) {
+  if (!status && !updated) {
+    return null;
+  }
+
+  return (
+    <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" alignItems="center">
+      {status ? <StatusChip label={status} /> : null}
+      {updated ? <MonoLabel>Updated {updated}</MonoLabel> : null}
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds shared molecules for CTA groups, project metadata rows, contact link lists, evidence links, and activity items.
- Adopts the current repeated project metadata, CTA, and contact link patterns on existing pages.
- Keeps the evidence and activity molecules small and data-driven for upcoming scoped sections without adding GitHub fetching.

## Validation
- npm run lint
- npm run format:check
- npm run build

Closes #9