### PR TITLE
[refactor]components: add page section organisms

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,8 @@
-import { ArrowForward } from "@mui/icons-material";
-import {
-  Box,
-  Card,
-  CardActions,
-  CardContent,
-  Divider,
-  Grid,
-  Stack,
-  Typography,
-} from "@mui/material";
+import { Divider, Stack } from "@mui/material";
 import type { Metadata } from "next";
 
-import { SectionEyebrow, SectionHeading, TechTag } from "@/components/atoms";
 import { MdxContent } from "@/components/mdx-content";
-import { CTAGroup, ProjectMetaRow } from "@/components/molecules";
+import { AuthorityHero, SelectedWorkSection, WorkingNowCard } from "@/components/organisms";
 import { getBio, getFeaturedProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 
@@ -26,78 +15,41 @@ export const metadata: Metadata = {
 
 export default async function HomePage() {
   const [bio, featuredProjects] = await Promise.all([getBio(), getFeaturedProjects()]);
+  const featuredProjectItems = featuredProjects.map((project) => ({
+    actionLabel: "View details",
+    href: toInternalHref(`/projects/${project.slug}`),
+    status: project.status,
+    summary: project.summary,
+    title: project.title,
+  }));
 
   return (
     <Stack spacing={7}>
-      <Box component="section" aria-labelledby="home-bio-heading">
-        <SectionHeading id="home-bio-heading" component="h1" variant="h1" gutterBottom>
-          {bio.frontmatter.title ?? "Alex Lucero"}
-        </SectionHeading>
+      <AuthorityHero
+        headingId="home-bio-heading"
+        techTags={["Next.js", "TypeScript", "MUI", "MDX"]}
+        title={bio.frontmatter.title ?? "Alex Lucero"}
+      >
         <MdxContent>{bio.content}</MdxContent>
-        <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ mt: 2 }}>
-          {["Next.js", "TypeScript", "MUI", "MDX"].map((tag) => (
-            <TechTag key={tag} label={tag} />
-          ))}
-        </Stack>
-      </Box>
+      </AuthorityHero>
 
       <Divider />
 
-      <Box component="section" aria-labelledby="featured-projects-heading">
-        <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2.5 }}>
-          <SectionHeading id="featured-projects-heading">Featured Projects</SectionHeading>
-          <CTAGroup
-            actions={[
-              {
-                endIcon: <ArrowForward />,
-                href: toInternalHref("/projects"),
-                label: "All projects",
-              },
-            ]}
-          />
-        </Stack>
-        <Grid container spacing={2.5}>
-          {featuredProjects.map((project) => (
-            <Grid key={project.slug} size={{ xs: 12, md: 6, lg: 4 }}>
-              <Card component="article">
-                <CardContent>
-                  <Typography component="h3" variant="h3" sx={{ fontSize: "1.35rem", mb: 1 }}>
-                    {project.title}
-                  </Typography>
-                  <Typography color="text.secondary" sx={{ mb: 2 }}>
-                    {project.summary}
-                  </Typography>
-                  <ProjectMetaRow status={project.status} />
-                </CardContent>
-                <CardActions>
-                  <CTAGroup
-                    actions={[
-                      {
-                        endIcon: <ArrowForward />,
-                        href: toInternalHref(`/projects/${project.slug}`),
-                        label: "View details",
-                      },
-                    ]}
-                  />
-                </CardActions>
-              </Card>
-            </Grid>
-          ))}
-        </Grid>
-      </Box>
+      <SelectedWorkSection
+        allProjectsHref={toInternalHref("/projects")}
+        headingId="featured-projects-heading"
+        projects={featuredProjectItems}
+      />
 
       <Divider />
 
-      <Box component="section" aria-labelledby="working-now-heading">
-        <SectionEyebrow>Now</SectionEyebrow>
-        <SectionHeading id="working-now-heading" sx={{ mb: 1.5 }}>
-          What I&apos;m Working On
-        </SectionHeading>
-        <Typography component="p" color="text.secondary">
-          {bio.frontmatter.now ??
-            "TODO: Add current work focus in /content/bio.mdx frontmatter `now`."}
-        </Typography>
-      </Box>
+      <WorkingNowCard
+        headingId="working-now-heading"
+        summary={
+          bio.frontmatter.now ??
+          "TODO: Add current work focus in /content/bio.mdx frontmatter `now`."
+        }
+      />
     </Stack>
   );
 }

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,11 +1,9 @@
-import { ArrowBack } from "@mui/icons-material";
-import { Box, Stack } from "@mui/material";
+import { Stack } from "@mui/material";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
-import { SectionHeading } from "@/components/atoms";
 import { MdxContent } from "@/components/mdx-content";
-import { CTAGroup, ProjectMetaRow } from "@/components/molecules";
+import { ProjectDetailHeader } from "@/components/organisms";
 import { getProjectBySlug, getProjectSlugs } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 
@@ -55,23 +53,12 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
 
   return (
     <Stack spacing={3.5}>
-      <Box component="header">
-        <Box sx={{ mb: 1.5 }}>
-          <CTAGroup
-            actions={[
-              {
-                href: toInternalHref("/projects"),
-                label: "Back to projects",
-                startIcon: <ArrowBack />,
-              },
-            ]}
-          />
-        </Box>
-        <SectionHeading component="h1" variant="h1" gutterBottom>
-          {project.frontmatter.title}
-        </SectionHeading>
-        <ProjectMetaRow status={project.frontmatter.status} updated={project.frontmatter.updated} />
-      </Box>
+      <ProjectDetailHeader
+        backHref={toInternalHref("/projects")}
+        status={project.frontmatter.status}
+        title={project.frontmatter.title ?? slug}
+        updated={project.frontmatter.updated}
+      />
 
       <MdxContent>{project.content}</MdxContent>
     </Stack>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,9 +1,8 @@
-import { ArrowForward } from "@mui/icons-material";
-import { Card, CardActions, CardContent, Grid, Stack, Typography } from "@mui/material";
+import { Stack } from "@mui/material";
 import type { Metadata } from "next";
 
 import { SectionHeading } from "@/components/atoms";
-import { CTAGroup, ProjectMetaRow } from "@/components/molecules";
+import { ProjectGrid } from "@/components/organisms";
 import { getAllProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 
@@ -17,40 +16,20 @@ export const metadata: Metadata = {
 
 export default async function ProjectsPage() {
   const projects = await getAllProjects();
+  const projectItems = projects.map((project) => ({
+    href: toInternalHref(`/projects/${project.slug}`),
+    status: project.status,
+    summary: project.summary,
+    title: project.title,
+    updated: project.updated,
+  }));
 
   return (
     <Stack spacing={3.5}>
       <SectionHeading component="h1" variant="h1">
         Projects
       </SectionHeading>
-      <Grid container spacing={2.5}>
-        {projects.map((project) => (
-          <Grid key={project.slug} size={{ xs: 12, md: 6 }}>
-            <Card component="article">
-              <CardContent>
-                <Typography component="h2" variant="h3" sx={{ fontSize: "1.45rem", mb: 1 }}>
-                  {project.title}
-                </Typography>
-                <Typography color="text.secondary" sx={{ mb: 2 }}>
-                  {project.summary}
-                </Typography>
-                <ProjectMetaRow status={project.status} updated={project.updated} />
-              </CardContent>
-              <CardActions>
-                <CTAGroup
-                  actions={[
-                    {
-                      endIcon: <ArrowForward />,
-                      href: toInternalHref(`/projects/${project.slug}`),
-                      label: "Open project",
-                    },
-                  ]}
-                />
-              </CardActions>
-            </Card>
-          </Grid>
-        ))}
-      </Grid>
+      <ProjectGrid projects={projectItems} />
     </Stack>
   );
 }

--- a/src/components/organisms/authority-hero.tsx
+++ b/src/components/organisms/authority-hero.tsx
@@ -1,0 +1,29 @@
+import { Box, Stack } from "@mui/material";
+import type { ReactNode } from "react";
+
+import { SectionHeading, TechTag } from "@/components/atoms";
+
+type AuthorityHeroProps = {
+  children: ReactNode;
+  headingId: string;
+  techTags?: string[];
+  title: string;
+};
+
+export function AuthorityHero({ children, headingId, techTags = [], title }: AuthorityHeroProps) {
+  return (
+    <Box component="section" aria-labelledby={headingId}>
+      <SectionHeading id={headingId} component="h1" variant="h1" gutterBottom>
+        {title}
+      </SectionHeading>
+      {children}
+      {techTags.length > 0 ? (
+        <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ mt: 2 }}>
+          {techTags.map((tag) => (
+            <TechTag key={tag} label={tag} />
+          ))}
+        </Stack>
+      ) : null}
+    </Box>
+  );
+}

--- a/src/components/organisms/build-philosophy-section.tsx
+++ b/src/components/organisms/build-philosophy-section.tsx
@@ -1,0 +1,46 @@
+import { Box, Card, CardContent, Grid, Typography } from "@mui/material";
+
+import { SectionHeading } from "@/components/atoms";
+
+export type BuildPrinciple = {
+  description: string;
+  title: string;
+};
+
+type BuildPhilosophySectionProps = {
+  headingId: string;
+  principles?: BuildPrinciple[];
+  title?: string;
+};
+
+export function BuildPhilosophySection({
+  headingId,
+  principles = [],
+  title = "Build Philosophy",
+}: BuildPhilosophySectionProps) {
+  if (principles.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box component="section" aria-labelledby={headingId}>
+      <SectionHeading id={headingId} sx={{ mb: 2.5 }}>
+        {title}
+      </SectionHeading>
+      <Grid container spacing={2.5}>
+        {principles.map((principle) => (
+          <Grid key={principle.title} size={{ xs: 12, md: 4 }}>
+            <Card component="article">
+              <CardContent>
+                <Typography component="h3" variant="h3" sx={{ fontSize: "1.25rem", mb: 1 }}>
+                  {principle.title}
+                </Typography>
+                <Typography color="text.secondary">{principle.description}</Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+}

--- a/src/components/organisms/engineering-evidence-section.tsx
+++ b/src/components/organisms/engineering-evidence-section.tsx
@@ -1,0 +1,29 @@
+import { Box } from "@mui/material";
+
+import { SectionHeading } from "@/components/atoms";
+import { EvidenceLinkList, type EvidenceLink } from "@/components/molecules";
+
+type EngineeringEvidenceSectionProps = {
+  headingId: string;
+  links?: EvidenceLink[];
+  title?: string;
+};
+
+export function EngineeringEvidenceSection({
+  headingId,
+  links = [],
+  title = "Engineering Evidence",
+}: EngineeringEvidenceSectionProps) {
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box component="section" aria-labelledby={headingId}>
+      <SectionHeading id={headingId} sx={{ mb: 2 }}>
+        {title}
+      </SectionHeading>
+      <EvidenceLinkList links={links} />
+    </Box>
+  );
+}

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -1,0 +1,9 @@
+export { AuthorityHero } from "./authority-hero";
+export { BuildPhilosophySection } from "./build-philosophy-section";
+export type { BuildPrinciple } from "./build-philosophy-section";
+export { EngineeringEvidenceSection } from "./engineering-evidence-section";
+export { ProjectDetailHeader } from "./project-detail-header";
+export { ProjectGrid } from "./project-grid";
+export type { ProjectGridItem } from "./project-grid";
+export { SelectedWorkSection } from "./selected-work-section";
+export { WorkingNowCard } from "./working-now-card";

--- a/src/components/organisms/project-detail-header.tsx
+++ b/src/components/organisms/project-detail-header.tsx
@@ -1,0 +1,39 @@
+import { ArrowBack } from "@mui/icons-material";
+import { Box } from "@mui/material";
+
+import { SectionHeading } from "@/components/atoms";
+import { CTAGroup, ProjectMetaRow } from "@/components/molecules";
+
+type ProjectDetailHeaderProps = {
+  backHref: string;
+  status?: string;
+  title: string;
+  updated?: string;
+};
+
+export function ProjectDetailHeader({
+  backHref,
+  status,
+  title,
+  updated,
+}: ProjectDetailHeaderProps) {
+  return (
+    <Box component="header">
+      <Box sx={{ mb: 1.5 }}>
+        <CTAGroup
+          actions={[
+            {
+              href: backHref,
+              label: "Back to projects",
+              startIcon: <ArrowBack />,
+            },
+          ]}
+        />
+      </Box>
+      <SectionHeading component="h1" variant="h1" gutterBottom>
+        {title}
+      </SectionHeading>
+      <ProjectMetaRow status={status} updated={updated} />
+    </Box>
+  );
+}

--- a/src/components/organisms/project-grid.tsx
+++ b/src/components/organisms/project-grid.tsx
@@ -1,0 +1,59 @@
+import { ArrowForward } from "@mui/icons-material";
+import { Card, CardActions, CardContent, Grid, Typography } from "@mui/material";
+
+import { CTAGroup, ProjectMetaRow } from "@/components/molecules";
+
+export type ProjectGridItem = {
+  actionLabel?: string;
+  href: string;
+  status?: string;
+  summary: string;
+  title: string;
+  updated?: string;
+};
+
+type ProjectGridProps = {
+  headingComponent?: "h2" | "h3";
+  projects: ProjectGridItem[];
+};
+
+export function ProjectGrid({ headingComponent = "h2", projects }: ProjectGridProps) {
+  if (projects.length === 0) {
+    return null;
+  }
+
+  return (
+    <Grid container spacing={2.5}>
+      {projects.map((project) => (
+        <Grid key={project.href} size={{ xs: 12, md: 6 }}>
+          <Card component="article">
+            <CardContent>
+              <Typography
+                component={headingComponent}
+                variant="h3"
+                sx={{ fontSize: headingComponent === "h2" ? "1.45rem" : "1.35rem", mb: 1 }}
+              >
+                {project.title}
+              </Typography>
+              <Typography color="text.secondary" sx={{ mb: 2 }}>
+                {project.summary}
+              </Typography>
+              <ProjectMetaRow status={project.status} updated={project.updated} />
+            </CardContent>
+            <CardActions>
+              <CTAGroup
+                actions={[
+                  {
+                    endIcon: <ArrowForward />,
+                    href: project.href,
+                    label: project.actionLabel ?? "Open project",
+                  },
+                ]}
+              />
+            </CardActions>
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}

--- a/src/components/organisms/selected-work-section.tsx
+++ b/src/components/organisms/selected-work-section.tsx
@@ -1,0 +1,38 @@
+import { ArrowForward } from "@mui/icons-material";
+import { Box, Stack } from "@mui/material";
+
+import { SectionHeading } from "@/components/atoms";
+import { CTAGroup } from "@/components/molecules";
+import { ProjectGrid, type ProjectGridItem } from "@/components/organisms/project-grid";
+
+type SelectedWorkSectionProps = {
+  allProjectsHref: string;
+  headingId: string;
+  projects: ProjectGridItem[];
+  title?: string;
+};
+
+export function SelectedWorkSection({
+  allProjectsHref,
+  headingId,
+  projects,
+  title = "Featured Projects",
+}: SelectedWorkSectionProps) {
+  return (
+    <Box component="section" aria-labelledby={headingId}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2.5 }}>
+        <SectionHeading id={headingId}>{title}</SectionHeading>
+        <CTAGroup
+          actions={[
+            {
+              endIcon: <ArrowForward />,
+              href: allProjectsHref,
+              label: "All projects",
+            },
+          ]}
+        />
+      </Stack>
+      <ProjectGrid headingComponent="h3" projects={projects} />
+    </Box>
+  );
+}

--- a/src/components/organisms/working-now-card.tsx
+++ b/src/components/organisms/working-now-card.tsx
@@ -1,0 +1,22 @@
+import { Box, Typography } from "@mui/material";
+
+import { SectionEyebrow, SectionHeading } from "@/components/atoms";
+
+type WorkingNowCardProps = {
+  headingId: string;
+  summary: string;
+};
+
+export function WorkingNowCard({ headingId, summary }: WorkingNowCardProps) {
+  return (
+    <Box component="section" aria-labelledby={headingId}>
+      <SectionEyebrow>Now</SectionEyebrow>
+      <SectionHeading id={headingId} sx={{ mb: 1.5 }}>
+        What I&apos;m Working On
+      </SectionHeading>
+      <Typography component="p" color="text.secondary">
+        {summary}
+      </Typography>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds presentational section organisms for authority hero, selected work, project grid, working-now fallback, project detail header, build philosophy, and engineering evidence.
- Adopts the organisms incrementally on the current home and project pages without adding GitHub fetching or rewriting the full homepage.
- Keeps data loading in route files and passes display data through props.

## Validation
- npm run lint
- npm run format:check
- npm run build

Closes #10