### PR TITLE
[refactor]templates: add reusable page templates

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,8 +1,9 @@
-import { Card, CardContent, Stack } from "@mui/material";
+import { Card, CardContent } from "@mui/material";
 import type { Metadata } from "next";
 
 import { SectionHeading } from "@/components/atoms";
 import { ContactLinkList } from "@/components/molecules";
+import { ContentPageTemplate } from "@/components/templates";
 import { getResume } from "@/lib/content";
 import { siteConfig } from "@/lib/site";
 
@@ -20,11 +21,7 @@ export default async function ContactPage() {
   const github = resume.frontmatter.github ?? siteConfig.github;
 
   return (
-    <Stack spacing={3.5}>
-      <SectionHeading component="h1" variant="h1">
-        Contact
-      </SectionHeading>
-
+    <ContentPageTemplate title="Contact">
       <Card component="section" aria-labelledby="contact-links-heading">
         <CardContent>
           <SectionHeading id="contact-links-heading" sx={{ mb: 2 }}>
@@ -40,6 +37,6 @@ export default async function ContactPage() {
           />
         </CardContent>
       </Card>
-    </Stack>
+    </ContentPageTemplate>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
-import { Divider, Stack } from "@mui/material";
 import type { Metadata } from "next";
 
 import { MdxContent } from "@/components/mdx-content";
 import { AuthorityHero, SelectedWorkSection, WorkingNowCard } from "@/components/organisms";
+import { HomeTemplate } from "@/components/templates";
 import { getBio, getFeaturedProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 
@@ -24,32 +24,31 @@ export default async function HomePage() {
   }));
 
   return (
-    <Stack spacing={7}>
-      <AuthorityHero
-        headingId="home-bio-heading"
-        techTags={["Next.js", "TypeScript", "MUI", "MDX"]}
-        title={bio.frontmatter.title ?? "Alex Lucero"}
-      >
-        <MdxContent>{bio.content}</MdxContent>
-      </AuthorityHero>
-
-      <Divider />
-
-      <SelectedWorkSection
-        allProjectsHref={toInternalHref("/projects")}
-        headingId="featured-projects-heading"
-        projects={featuredProjectItems}
-      />
-
-      <Divider />
-
-      <WorkingNowCard
-        headingId="working-now-heading"
-        summary={
-          bio.frontmatter.now ??
-          "TODO: Add current work focus in /content/bio.mdx frontmatter `now`."
-        }
-      />
-    </Stack>
+    <HomeTemplate
+      sections={[
+        <AuthorityHero
+          key="hero"
+          headingId="home-bio-heading"
+          techTags={["Next.js", "TypeScript", "MUI", "MDX"]}
+          title={bio.frontmatter.title ?? "Alex Lucero"}
+        >
+          <MdxContent>{bio.content}</MdxContent>
+        </AuthorityHero>,
+        <SelectedWorkSection
+          key="selected-work"
+          allProjectsHref={toInternalHref("/projects")}
+          headingId="featured-projects-heading"
+          projects={featuredProjectItems}
+        />,
+        <WorkingNowCard
+          key="working-now"
+          headingId="working-now-heading"
+          summary={
+            bio.frontmatter.now ??
+            "TODO: Add current work focus in /content/bio.mdx frontmatter `now`."
+          }
+        />,
+      ]}
+    />
   );
 }

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,9 +1,9 @@
-import { Stack } from "@mui/material";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { MdxContent } from "@/components/mdx-content";
 import { ProjectDetailHeader } from "@/components/organisms";
+import { ProjectDetailTemplate } from "@/components/templates";
 import { getProjectBySlug, getProjectSlugs } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 
@@ -52,15 +52,17 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
   }
 
   return (
-    <Stack spacing={3.5}>
-      <ProjectDetailHeader
-        backHref={toInternalHref("/projects")}
-        status={project.frontmatter.status}
-        title={project.frontmatter.title ?? slug}
-        updated={project.frontmatter.updated}
-      />
-
+    <ProjectDetailTemplate
+      header={
+        <ProjectDetailHeader
+          backHref={toInternalHref("/projects")}
+          status={project.frontmatter.status}
+          title={project.frontmatter.title ?? slug}
+          updated={project.frontmatter.updated}
+        />
+      }
+    >
       <MdxContent>{project.content}</MdxContent>
-    </Stack>
+    </ProjectDetailTemplate>
   );
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,8 +1,7 @@
-import { Stack } from "@mui/material";
 import type { Metadata } from "next";
 
-import { SectionHeading } from "@/components/atoms";
 import { ProjectGrid } from "@/components/organisms";
+import { ProjectIndexTemplate } from "@/components/templates";
 import { getAllProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 
@@ -25,11 +24,8 @@ export default async function ProjectsPage() {
   }));
 
   return (
-    <Stack spacing={3.5}>
-      <SectionHeading component="h1" variant="h1">
-        Projects
-      </SectionHeading>
+    <ProjectIndexTemplate title="Projects">
       <ProjectGrid projects={projectItems} />
-    </Stack>
+    </ProjectIndexTemplate>
   );
 }

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,8 +1,8 @@
-import { Box, Button, Stack } from "@mui/material";
+import { Button } from "@mui/material";
 import type { Metadata } from "next";
 
-import { SectionHeading } from "@/components/atoms";
 import { MdxContent } from "@/components/mdx-content";
+import { ContentPageTemplate } from "@/components/templates";
 import { getResume } from "@/lib/content";
 
 export const dynamic = "force-static";
@@ -17,17 +17,15 @@ export default async function ResumePage() {
   const pdfPath = resume.frontmatter.pdfPath ?? "/resume/Alex_Lucero_Resume.pdf";
 
   return (
-    <Stack spacing={3}>
-      <Box component="header">
-        <SectionHeading component="h1" variant="h1" gutterBottom>
-          {resume.frontmatter.title ?? "Resume"}
-        </SectionHeading>
+    <ContentPageTemplate
+      actions={
         <Button href={pdfPath} variant="contained" component="a" download>
           Download PDF
         </Button>
-      </Box>
-
+      }
+      title={resume.frontmatter.title ?? "Resume"}
+    >
       <MdxContent>{resume.content}</MdxContent>
-    </Stack>
+    </ContentPageTemplate>
   );
 }

--- a/src/components/templates/content-page-template.tsx
+++ b/src/components/templates/content-page-template.tsx
@@ -1,0 +1,24 @@
+import { Box, Stack } from "@mui/material";
+import type { ReactNode } from "react";
+
+import { SectionHeading } from "@/components/atoms";
+
+type ContentPageTemplateProps = {
+  actions?: ReactNode;
+  children: ReactNode;
+  title: string;
+};
+
+export function ContentPageTemplate({ actions, children, title }: ContentPageTemplateProps) {
+  return (
+    <Stack spacing={3.5}>
+      <Box component="header">
+        <SectionHeading component="h1" variant="h1" gutterBottom={Boolean(actions)}>
+          {title}
+        </SectionHeading>
+        {actions}
+      </Box>
+      {children}
+    </Stack>
+  );
+}

--- a/src/components/templates/home-template.tsx
+++ b/src/components/templates/home-template.tsx
@@ -1,0 +1,19 @@
+import { Divider, Stack } from "@mui/material";
+import type { ReactNode } from "react";
+
+type HomeTemplateProps = {
+  sections: ReactNode[];
+};
+
+export function HomeTemplate({ sections }: HomeTemplateProps) {
+  return (
+    <Stack spacing={7}>
+      {sections.map((section, index) => (
+        <Stack key={index} spacing={7}>
+          {index > 0 ? <Divider /> : null}
+          {section}
+        </Stack>
+      ))}
+    </Stack>
+  );
+}

--- a/src/components/templates/index.ts
+++ b/src/components/templates/index.ts
@@ -1,0 +1,4 @@
+export { ContentPageTemplate } from "./content-page-template";
+export { HomeTemplate } from "./home-template";
+export { ProjectDetailTemplate } from "./project-detail-template";
+export { ProjectIndexTemplate } from "./project-index-template";

--- a/src/components/templates/project-detail-template.tsx
+++ b/src/components/templates/project-detail-template.tsx
@@ -1,0 +1,16 @@
+import { Stack } from "@mui/material";
+import type { ReactNode } from "react";
+
+type ProjectDetailTemplateProps = {
+  children: ReactNode;
+  header: ReactNode;
+};
+
+export function ProjectDetailTemplate({ children, header }: ProjectDetailTemplateProps) {
+  return (
+    <Stack spacing={3.5}>
+      {header}
+      {children}
+    </Stack>
+  );
+}

--- a/src/components/templates/project-index-template.tsx
+++ b/src/components/templates/project-index-template.tsx
@@ -1,0 +1,20 @@
+import { Stack } from "@mui/material";
+import type { ReactNode } from "react";
+
+import { SectionHeading } from "@/components/atoms";
+
+type ProjectIndexTemplateProps = {
+  children: ReactNode;
+  title: string;
+};
+
+export function ProjectIndexTemplate({ children, title }: ProjectIndexTemplateProps) {
+  return (
+    <Stack spacing={3.5}>
+      <SectionHeading component="h1" variant="h1">
+        {title}
+      </SectionHeading>
+      {children}
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds lightweight templates for home composition, content pages, project index, and project detail layout.
- Keeps route files responsible for static flags, metadata, and data loading.
- Wires each template into an existing page immediately without route changes.

## Validation
- npm run lint
- npm run format:check
- npm run build

Closes #11