### PR TITLE
[feat]home: implement founder-led authority hero

### DIFF
--- a/content/bio.mdx
+++ b/content/bio.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Alex Lucero"
-description: "Short bio for portfolio homepage."
+description: "Founder-led technical systems portfolio for Alex Lucero and Loose Arrow Labs."
 now: "Codex, Kittybot, VTCN"
 ---
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { AuthorityHero, SelectedWorkSection, WorkingNowCard } from "@/components
 import { HomeTemplate } from "@/components/templates";
 import { getBio, getFeaturedProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
+import { siteConfig } from "@/lib/site";
 
 export const dynamic = "force-static";
 
@@ -28,7 +29,21 @@ export default async function HomePage() {
       sections={[
         <AuthorityHero
           key="hero"
+          ctas={[
+            {
+              href: "#featured-projects-heading",
+              label: "Selected work",
+              variant: "contained",
+            },
+            {
+              href: toInternalHref("/contact"),
+              label: "Contact",
+              variant: "outlined",
+            },
+          ]}
+          eyebrow={`${siteConfig.ownerName} / ${siteConfig.studioName}`}
           headingId="home-bio-heading"
+          summary="I build practical software, automation, and systems-integration projects with an emphasis on reliability, documentation, and proof you can inspect."
           techTags={["Next.js", "TypeScript", "MUI", "MDX"]}
           title={bio.frontmatter.title ?? "Alex Lucero"}
         >

--- a/src/components/organisms/authority-hero.tsx
+++ b/src/components/organisms/authority-hero.tsx
@@ -1,24 +1,51 @@
-import { Box, Stack } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import type { ReactNode } from "react";
 
-import { SectionHeading, TechTag } from "@/components/atoms";
+import { SectionEyebrow, SectionHeading, TechTag } from "@/components/atoms";
+import { CTAGroup } from "@/components/molecules";
+
+type HeroCTA = {
+  href: string;
+  label: string;
+  variant?: "contained" | "outlined" | "text";
+};
 
 type AuthorityHeroProps = {
   children: ReactNode;
+  ctas?: HeroCTA[];
+  eyebrow?: string;
   headingId: string;
+  summary?: string;
   techTags?: string[];
   title: string;
 };
 
-export function AuthorityHero({ children, headingId, techTags = [], title }: AuthorityHeroProps) {
+export function AuthorityHero({
+  children,
+  ctas = [],
+  eyebrow,
+  headingId,
+  summary,
+  techTags = [],
+  title,
+}: AuthorityHeroProps) {
   return (
     <Box component="section" aria-labelledby={headingId}>
-      <SectionHeading id={headingId} component="h1" variant="h1" gutterBottom>
-        {title}
-      </SectionHeading>
-      {children}
+      <Stack spacing={2.5} sx={{ maxWidth: 880 }}>
+        {eyebrow ? <SectionEyebrow>{eyebrow}</SectionEyebrow> : null}
+        <SectionHeading id={headingId} component="h1" variant="h1">
+          {title}
+        </SectionHeading>
+        {summary ? (
+          <Typography component="p" variant="h2" sx={{ color: "text.secondary", maxWidth: 760 }}>
+            {summary}
+          </Typography>
+        ) : null}
+        {ctas.length > 0 ? <CTAGroup actions={ctas} /> : null}
+        <Box sx={{ maxWidth: 760 }}>{children}</Box>
+      </Stack>
       {techTags.length > 0 ? (
-        <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ mt: 2 }}>
+        <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ mt: 3 }}>
           {techTags.map((tag) => (
             <TechTag key={tag} label={tag} />
           ))}


### PR DESCRIPTION
## Summary
- Updates the home hero to lead with Alex Lucero and support Loose Arrow Labs as the studio identity.
- Adds direct technical positioning and clear CTAs to selected work and contact.
- Keeps the longer MDX bio as supporting authored content and preserves static-first rendering.

## Validation
- npm run lint
- npm run format:check
- npm run build

## Visual Summary
The first homepage section now reads as a founder-led authority hero instead of a simple bio block, without SaaS or agency-style claims.

Closes #12