### PR TITLE
[feat]home: add what-we-do section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,13 @@
 import type { Metadata } from "next";
 
 import { MdxContent } from "@/components/mdx-content";
-import { AuthorityHero, SelectedWorkSection, WorkingNowCard } from "@/components/organisms";
+import {
+  AuthorityHero,
+  SelectedWorkSection,
+  WhatWeDoSection,
+  type WhatWeDoItem,
+  WorkingNowCard,
+} from "@/components/organisms";
 import { HomeTemplate } from "@/components/templates";
 import { getBio, getFeaturedProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
@@ -13,6 +19,24 @@ export const metadata: Metadata = {
   title: "Home",
   description: "Alex Lucero portfolio home with bio, featured projects, and current work focus.",
 };
+
+const whatWeDoItems: WhatWeDoItem[] = [
+  {
+    title: "Systems structuring",
+    description:
+      "Turn ambiguous technical work into explicit boundaries, data shapes, implementation paths, and validation steps.",
+  },
+  {
+    title: "AI integration",
+    description:
+      "Use LLMs where they improve retrieval, automation, and operator flow without making live AI the source of truth.",
+  },
+  {
+    title: "Supportable prototypes",
+    description:
+      "Build small, inspectable slices with enough documentation, tests, and tradeoff notes to keep moving after the demo.",
+  },
+];
 
 export default async function HomePage() {
   const [bio, featuredProjects] = await Promise.all([getBio(), getFeaturedProjects()]);
@@ -49,6 +73,7 @@ export default async function HomePage() {
         >
           <MdxContent>{bio.content}</MdxContent>
         </AuthorityHero>,
+        <WhatWeDoSection key="what-we-do" headingId="what-we-do-heading" items={whatWeDoItems} />,
         <SelectedWorkSection
           key="selected-work"
           allProjectsHref={toInternalHref("/projects")}

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -6,4 +6,6 @@ export { ProjectDetailHeader } from "./project-detail-header";
 export { ProjectGrid } from "./project-grid";
 export type { ProjectGridItem } from "./project-grid";
 export { SelectedWorkSection } from "./selected-work-section";
+export { WhatWeDoSection } from "./what-we-do-section";
+export type { WhatWeDoItem } from "./what-we-do-section";
 export { WorkingNowCard } from "./working-now-card";

--- a/src/components/organisms/what-we-do-section.tsx
+++ b/src/components/organisms/what-we-do-section.tsx
@@ -1,0 +1,46 @@
+import { Box, Card, CardContent, Grid, Typography } from "@mui/material";
+
+import { SectionHeading } from "@/components/atoms";
+
+export type WhatWeDoItem = {
+  description: string;
+  title: string;
+};
+
+type WhatWeDoSectionProps = {
+  headingId: string;
+  items: WhatWeDoItem[];
+  title?: string;
+};
+
+export function WhatWeDoSection({
+  headingId,
+  items,
+  title = "What I Do Through Loose Arrow Labs",
+}: WhatWeDoSectionProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box component="section" aria-labelledby={headingId}>
+      <SectionHeading id={headingId} sx={{ mb: 2.5 }}>
+        {title}
+      </SectionHeading>
+      <Grid container spacing={2.5}>
+        {items.map((item) => (
+          <Grid key={item.title} size={{ xs: 12, md: 4 }}>
+            <Card component="article">
+              <CardContent>
+                <Typography component="h3" variant="h3" sx={{ fontSize: "1.25rem", mb: 1 }}>
+                  {item.title}
+                </Typography>
+                <Typography color="text.secondary">{item.description}</Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a local/static What We Do section focused on systems structuring, AI integration, and supportable prototypes.
- Keeps the copy founder-led and technical, with Loose Arrow Labs as the studio layer rather than an agency wrapper.
- Uses the existing atom/organism structure from the component-system milestone.

## Validation
- npm run lint
- npm run format:check
- npm run build

## Visual Summary
The homepage now has a concise capability section between the hero and selected work, rendered as three scan-friendly cards.

Closes #13