### PR TITLE
[feat]home: add selected work section

### DIFF
--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -3,4 +3,6 @@ export { ContactLinkList } from "./contact-link-list";
 export { CTAGroup } from "./cta-group";
 export { EvidenceLinkList } from "./evidence-link-list";
 export type { EvidenceLink } from "./evidence-link-list";
+export { ProjectCard } from "./project-card";
+export type { ProjectCardData } from "./project-card";
 export { ProjectMetaRow } from "./project-meta-row";

--- a/src/components/molecules/project-card.tsx
+++ b/src/components/molecules/project-card.tsx
@@ -1,0 +1,57 @@
+import { ArrowForward } from "@mui/icons-material";
+import { Card, CardActions, CardContent, Typography } from "@mui/material";
+
+import { CTAGroup } from "./cta-group";
+import { ProjectMetaRow } from "./project-meta-row";
+
+export type ProjectCardData = {
+  actionLabel?: string;
+  href: string;
+  status?: string;
+  summary: string;
+  title: string;
+  updated?: string;
+};
+
+type ProjectCardProps = ProjectCardData & {
+  headingComponent?: "h2" | "h3";
+};
+
+export function ProjectCard({
+  actionLabel = "Open project",
+  headingComponent = "h2",
+  href,
+  status,
+  summary,
+  title,
+  updated,
+}: ProjectCardProps) {
+  return (
+    <Card component="article">
+      <CardContent>
+        <Typography
+          component={headingComponent}
+          variant="h3"
+          sx={{ fontSize: headingComponent === "h2" ? "1.45rem" : "1.35rem", mb: 1 }}
+        >
+          {title}
+        </Typography>
+        <Typography color="text.secondary" sx={{ mb: 2 }}>
+          {summary}
+        </Typography>
+        <ProjectMetaRow status={status} updated={updated} />
+      </CardContent>
+      <CardActions>
+        <CTAGroup
+          actions={[
+            {
+              endIcon: <ArrowForward />,
+              href,
+              label: actionLabel,
+            },
+          ]}
+        />
+      </CardActions>
+    </Card>
+  );
+}

--- a/src/components/organisms/project-grid.tsx
+++ b/src/components/organisms/project-grid.tsx
@@ -1,16 +1,8 @@
-import { ArrowForward } from "@mui/icons-material";
-import { Card, CardActions, CardContent, Grid, Typography } from "@mui/material";
+import { Grid } from "@mui/material";
 
-import { CTAGroup, ProjectMetaRow } from "@/components/molecules";
+import { ProjectCard, type ProjectCardData } from "@/components/molecules";
 
-export type ProjectGridItem = {
-  actionLabel?: string;
-  href: string;
-  status?: string;
-  summary: string;
-  title: string;
-  updated?: string;
-};
+export type ProjectGridItem = ProjectCardData;
 
 type ProjectGridProps = {
   headingComponent?: "h2" | "h3";
@@ -26,32 +18,7 @@ export function ProjectGrid({ headingComponent = "h2", projects }: ProjectGridPr
     <Grid container spacing={2.5}>
       {projects.map((project) => (
         <Grid key={project.href} size={{ xs: 12, md: 6 }}>
-          <Card component="article">
-            <CardContent>
-              <Typography
-                component={headingComponent}
-                variant="h3"
-                sx={{ fontSize: headingComponent === "h2" ? "1.45rem" : "1.35rem", mb: 1 }}
-              >
-                {project.title}
-              </Typography>
-              <Typography color="text.secondary" sx={{ mb: 2 }}>
-                {project.summary}
-              </Typography>
-              <ProjectMetaRow status={project.status} updated={project.updated} />
-            </CardContent>
-            <CardActions>
-              <CTAGroup
-                actions={[
-                  {
-                    endIcon: <ArrowForward />,
-                    href: project.href,
-                    label: project.actionLabel ?? "Open project",
-                  },
-                ]}
-              />
-            </CardActions>
-          </Card>
+          <ProjectCard {...project} headingComponent={headingComponent} />
         </Grid>
       ))}
     </Grid>

--- a/src/components/organisms/selected-work-section.tsx
+++ b/src/components/organisms/selected-work-section.tsx
@@ -1,5 +1,5 @@
 import { ArrowForward } from "@mui/icons-material";
-import { Box, Stack } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 
 import { SectionHeading } from "@/components/atoms";
 import { CTAGroup } from "@/components/molecules";
@@ -7,6 +7,7 @@ import { ProjectGrid, type ProjectGridItem } from "@/components/organisms/projec
 
 type SelectedWorkSectionProps = {
   allProjectsHref: string;
+  description?: string;
   headingId: string;
   projects: ProjectGridItem[];
   title?: string;
@@ -14,14 +15,20 @@ type SelectedWorkSectionProps = {
 
 export function SelectedWorkSection({
   allProjectsHref,
+  description = "Representative projects where the architecture, constraints, and implementation details are part of the evidence.",
   headingId,
   projects,
-  title = "Featured Projects",
+  title = "Selected Work",
 }: SelectedWorkSectionProps) {
   return (
     <Box component="section" aria-labelledby={headingId}>
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2.5 }}>
-        <SectionHeading id={headingId}>{title}</SectionHeading>
+        <Box>
+          <SectionHeading id={headingId}>{title}</SectionHeading>
+          <Typography color="text.secondary" sx={{ maxWidth: 720 }}>
+            {description}
+          </Typography>
+        </Box>
         <CTAGroup
           actions={[
             {


### PR DESCRIPTION
## Summary
- Refines the homepage featured-project area into a Selected Work section.
- Extracts a reusable ProjectCard molecule used by ProjectGrid.
- Keeps featured projects sourced from MDX via the existing getFeaturedProjects flow and leaves room for later freshness decoration.

## Validation
- npm run lint
- npm run format:check
- npm run build

## Visual Summary
The section now has authority-oriented framing plus cards with title, summary, status/update metadata when available, and a clear detail link.

Closes #14