### PR TITLE
[feat]home: add build philosophy and proof sections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,12 +3,16 @@ import type { Metadata } from "next";
 import { MdxContent } from "@/components/mdx-content";
 import {
   AuthorityHero,
+  BuildPhilosophySection,
+  type BuildPrinciple,
+  EngineeringEvidenceSection,
   SelectedWorkSection,
   WhatWeDoSection,
   type WhatWeDoItem,
   WorkingNowCard,
 } from "@/components/organisms";
 import { HomeTemplate } from "@/components/templates";
+import type { EvidenceLink } from "@/components/molecules";
 import { getBio, getFeaturedProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 import { siteConfig } from "@/lib/site";
@@ -38,6 +42,24 @@ const whatWeDoItems: WhatWeDoItem[] = [
   },
 ];
 
+const buildPrinciples: BuildPrinciple[] = [
+  {
+    title: "Define the boundary",
+    description:
+      "Name the interfaces, ownership, failure modes, and data shapes before the implementation gets too clever.",
+  },
+  {
+    title: "Validate the risky part",
+    description:
+      "Prototype around the unknowns first, then keep the validation steps close enough that future changes can be checked.",
+  },
+  {
+    title: "Leave a trail",
+    description:
+      "Prefer docs, decisions, run notes, and small tests over invisible heroics. The next pass should be easier to reason about.",
+  },
+];
+
 export default async function HomePage() {
   const [bio, featuredProjects] = await Promise.all([getBio(), getFeaturedProjects()]);
   const featuredProjectItems = featuredProjects.map((project) => ({
@@ -47,6 +69,24 @@ export default async function HomePage() {
     summary: project.summary,
     title: project.title,
   }));
+  const evidenceLinks: EvidenceLink[] = [
+    {
+      description: "Authored project pages with summaries, status, and implementation context.",
+      href: toInternalHref("/projects"),
+      label: "Project evidence index",
+    },
+    {
+      description: "Embedded Linux and telemetry work where interfaces and validation matter.",
+      href: toInternalHref("/projects/vtcn"),
+      label: "Embedded systems proof surface",
+    },
+    {
+      description:
+        "Homelab infrastructure work for repeatable operations and supportable services.",
+      href: toInternalHref("/projects/pantheon"),
+      label: "Infrastructure proof surface",
+    },
+  ];
 
   return (
     <HomeTemplate
@@ -79,6 +119,18 @@ export default async function HomePage() {
           allProjectsHref={toInternalHref("/projects")}
           headingId="featured-projects-heading"
           projects={featuredProjectItems}
+        />,
+        <BuildPhilosophySection
+          key="build-philosophy"
+          headingId="build-philosophy-heading"
+          principles={buildPrinciples}
+          title="How I Work"
+        />,
+        <EngineeringEvidenceSection
+          key="engineering-evidence"
+          headingId="engineering-evidence-heading"
+          links={evidenceLinks}
+          title="Proof of Work"
         />,
         <WorkingNowCard
           key="working-now"

--- a/src/components/molecules/evidence-link-list.tsx
+++ b/src/components/molecules/evidence-link-list.tsx
@@ -1,4 +1,4 @@
-import { List, ListItem, ListItemText } from "@mui/material";
+import { Link, List, ListItem, ListItemText } from "@mui/material";
 
 import { ExternalLink } from "@/components/atoms";
 
@@ -22,7 +22,13 @@ export function EvidenceLinkList({ links = [] }: EvidenceLinkListProps) {
       {links.map((link) => (
         <ListItem key={link.href} disableGutters>
           <ListItemText
-            primary={<ExternalLink href={link.href}>{link.label}</ExternalLink>}
+            primary={
+              link.href.startsWith("http") ? (
+                <ExternalLink href={link.href}>{link.label}</ExternalLink>
+              ) : (
+                <Link href={link.href}>{link.label}</Link>
+              )
+            }
             secondary={link.description}
           />
         </ListItem>


### PR DESCRIPTION
## Summary
- Adds local/static How I Work and Proof of Work sections to the homepage.
- Frames build philosophy around boundaries, validation, documentation, and supportability.
- Points proof toward existing project surfaces without fake metrics, testimonials, or fabricated artifacts.

## Validation
- npm run lint
- npm run format:check
- npm run build

## Visual Summary
The homepage now includes three build-principle cards and a proof list that links to existing project evidence surfaces.

Closes #15