### PR TITLE
[feat]home: add working-now fallback, about preview, and contact CTA

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,9 +2,11 @@ import type { Metadata } from "next";
 
 import { MdxContent } from "@/components/mdx-content";
 import {
+  AboutPreviewSection,
   AuthorityHero,
   BuildPhilosophySection,
   type BuildPrinciple,
+  ContactCTASection,
   EngineeringEvidenceSection,
   SelectedWorkSection,
   WhatWeDoSection,
@@ -12,7 +14,7 @@ import {
   WorkingNowCard,
 } from "@/components/organisms";
 import { HomeTemplate } from "@/components/templates";
-import type { EvidenceLink } from "@/components/molecules";
+import type { ActivityItemData, EvidenceLink } from "@/components/molecules";
 import { getBio, getFeaturedProjects } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
 import { siteConfig } from "@/lib/site";
@@ -57,6 +59,27 @@ const buildPrinciples: BuildPrinciple[] = [
     title: "Leave a trail",
     description:
       "Prefer docs, decisions, run notes, and small tests over invisible heroics. The next pass should be easier to reason about.",
+  },
+];
+
+const workingNowFallbackItems: ActivityItemData[] = [
+  {
+    label: "Current focus",
+    summary:
+      "Personal retrieval and documentation workflows for project decisions, procedures, and engineering notes.",
+    title: "Codex",
+  },
+  {
+    label: "Systems integration",
+    summary:
+      "Companion robot planning, service boundaries, and hardware/software interface contracts.",
+    title: "KittyBot",
+  },
+  {
+    label: "Embedded Linux",
+    summary:
+      "Telemetry platform work around sensor input, framing, persistence, and validation loops.",
+    title: "VTCN",
   },
 ];
 
@@ -135,10 +158,23 @@ export default async function HomePage() {
         <WorkingNowCard
           key="working-now"
           headingId="working-now-heading"
+          items={workingNowFallbackItems}
           summary={
             bio.frontmatter.now ??
             "TODO: Add current work focus in /content/bio.mdx frontmatter `now`."
           }
+        />,
+        <AboutPreviewSection
+          key="about-preview"
+          aboutHref={toInternalHref("/about")}
+          headingId="about-preview-heading"
+          summary="The site is centered on Alex Lucero: a software engineer using Loose Arrow Labs as the studio identity for hands-on technical work, systems experiments, and selected builds."
+        />,
+        <ContactCTASection
+          key="contact-cta"
+          contactHref={toInternalHref("/contact")}
+          headingId="contact-cta-heading"
+          summary="Send the project, system, or workflow constraint. The useful first step is usually clarifying boundaries, risks, and what would count as proof."
         />,
       ]}
     />

--- a/src/components/molecules/activity-item.tsx
+++ b/src/components/molecules/activity-item.tsx
@@ -2,14 +2,14 @@ import { Stack, Typography } from "@mui/material";
 
 import { ExternalLink, MonoLabel } from "@/components/atoms";
 
-type ActivityItemProps = {
+export type ActivityItemData = {
   href?: string;
   label?: string;
   summary?: string;
   title: string;
 };
 
-export function ActivityItem({ href, label, summary, title }: ActivityItemProps) {
+export function ActivityItem({ href, label, summary, title }: ActivityItemData) {
   return (
     <Stack spacing={0.5}>
       {label ? <MonoLabel>{label}</MonoLabel> : null}

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,4 +1,5 @@
 export { ActivityItem } from "./activity-item";
+export type { ActivityItemData } from "./activity-item";
 export { ContactLinkList } from "./contact-link-list";
 export { CTAGroup } from "./cta-group";
 export { EvidenceLinkList } from "./evidence-link-list";

--- a/src/components/organisms/about-preview-section.tsx
+++ b/src/components/organisms/about-preview-section.tsx
@@ -1,0 +1,25 @@
+import { Box, Typography } from "@mui/material";
+
+import { SectionEyebrow, SectionHeading } from "@/components/atoms";
+import { CTAGroup } from "@/components/molecules";
+
+type AboutPreviewSectionProps = {
+  aboutHref: string;
+  headingId: string;
+  summary: string;
+};
+
+export function AboutPreviewSection({ aboutHref, headingId, summary }: AboutPreviewSectionProps) {
+  return (
+    <Box component="section" aria-labelledby={headingId}>
+      <SectionEyebrow>About</SectionEyebrow>
+      <SectionHeading id={headingId} sx={{ mb: 1.5 }}>
+        Founder-led technical work
+      </SectionHeading>
+      <Typography color="text.secondary" sx={{ maxWidth: 760, mb: 2.5 }}>
+        {summary}
+      </Typography>
+      <CTAGroup actions={[{ href: aboutHref, label: "Read about Alex", variant: "outlined" }]} />
+    </Box>
+  );
+}

--- a/src/components/organisms/contact-cta-section.tsx
+++ b/src/components/organisms/contact-cta-section.tsx
@@ -1,0 +1,24 @@
+import { Box, Typography } from "@mui/material";
+
+import { SectionHeading } from "@/components/atoms";
+import { CTAGroup } from "@/components/molecules";
+
+type ContactCTASectionProps = {
+  contactHref: string;
+  headingId: string;
+  summary: string;
+};
+
+export function ContactCTASection({ contactHref, headingId, summary }: ContactCTASectionProps) {
+  return (
+    <Box component="section" aria-labelledby={headingId}>
+      <SectionHeading id={headingId} sx={{ mb: 1.5 }}>
+        Start with the constraint
+      </SectionHeading>
+      <Typography color="text.secondary" sx={{ maxWidth: 720, mb: 2.5 }}>
+        {summary}
+      </Typography>
+      <CTAGroup actions={[{ href: contactHref, label: "Contact Alex", variant: "contained" }]} />
+    </Box>
+  );
+}

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -1,6 +1,8 @@
+export { AboutPreviewSection } from "./about-preview-section";
 export { AuthorityHero } from "./authority-hero";
 export { BuildPhilosophySection } from "./build-philosophy-section";
 export type { BuildPrinciple } from "./build-philosophy-section";
+export { ContactCTASection } from "./contact-cta-section";
 export { EngineeringEvidenceSection } from "./engineering-evidence-section";
 export { ProjectDetailHeader } from "./project-detail-header";
 export { ProjectGrid } from "./project-grid";

--- a/src/components/organisms/working-now-card.tsx
+++ b/src/components/organisms/working-now-card.tsx
@@ -1,13 +1,15 @@
-import { Box, Typography } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 
 import { SectionEyebrow, SectionHeading } from "@/components/atoms";
+import { ActivityItem, type ActivityItemData } from "@/components/molecules";
 
 type WorkingNowCardProps = {
   headingId: string;
+  items?: ActivityItemData[];
   summary: string;
 };
 
-export function WorkingNowCard({ headingId, summary }: WorkingNowCardProps) {
+export function WorkingNowCard({ headingId, items = [], summary }: WorkingNowCardProps) {
   return (
     <Box component="section" aria-labelledby={headingId}>
       <SectionEyebrow>Now</SectionEyebrow>
@@ -17,6 +19,13 @@ export function WorkingNowCard({ headingId, summary }: WorkingNowCardProps) {
       <Typography component="p" color="text.secondary">
         {summary}
       </Typography>
+      {items.length > 0 ? (
+        <Stack spacing={2} sx={{ mt: 2.5 }}>
+          {items.map((item) => (
+            <ActivityItem key={item.title} {...item} />
+          ))}
+        </Stack>
+      ) : null}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- Adds local working-now fallback items without requiring GitHub data.
- Adds an about preview linking to the planned /about route.
- Adds a direct contact CTA that keeps the ask practical and low-friction.

## Validation
- npm run lint
- npm run format:check
- npm run build

## Visual Summary
The homepage static section map is now complete before live GitHub activity: working-now fallback, about preview, and final contact CTA all render from local content/config.

Closes #16