### PR TITLE
[feat]about: add founder-led about page

### DIFF
--- a/content/about.mdx
+++ b/content/about.mdx
@@ -1,0 +1,24 @@
+---
+title: "About Alex Lucero"
+description: "Founder context, technical direction, and working style for Alex Lucero and Loose Arrow Labs."
+---
+
+I am Alex Lucero, a software engineer focused on reliable systems, practical automation, and hardware-adjacent software work. My background is rooted in production application development, with growing emphasis on embedded Linux, robotics-adjacent systems, telemetry, and infrastructure that can be operated and understood over time.
+
+Loose Arrow Labs is the studio identity I use for selected builds and experiments. It is not a detached agency wrapper; it is a way to group hands-on technical work, project evidence, and the systems I am building in public.
+
+## Working Style
+
+I prefer to start by making the system easier to reason about: boundaries, data ownership, failure modes, and validation steps. The goal is not to make the first version impressive. The goal is to make the next version safer to change.
+
+I care about documentation, logs, repeatable setup, and visible tradeoffs because those are the things that keep software alive after the first demo. When a project touches hardware, infrastructure, or AI tooling, I try to keep authored context as the source of truth and use automation as support.
+
+## Current Direction
+
+The work I am shaping now centers on three threads:
+
+- embedded Linux and telemetry projects that show interface design, validation, and service reliability
+- AI-assisted documentation and retrieval workflows that help engineering decisions stay findable
+- homelab and infrastructure projects that exercise operations, observability, and repeatable change
+
+The portfolio is meant to make that work inspectable through project pages, notes, evidence links, and steady improvements rather than polished claims that cannot be checked.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+
+import { MdxContent } from "@/components/mdx-content";
+import { ContentPageTemplate } from "@/components/templates";
+import { getAbout } from "@/lib/content";
+
+export const dynamic = "force-static";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const about = await getAbout();
+
+  return {
+    title: about.frontmatter.title ?? "About",
+    description:
+      about.frontmatter.description ?? "Founder context and technical direction for Alex Lucero.",
+  };
+}
+
+export default async function AboutPage() {
+  const about = await getAbout();
+
+  return (
+    <ContentPageTemplate title={about.frontmatter.title ?? "About Alex Lucero"}>
+      <MdxContent>{about.content}</MdxContent>
+    </ContentPageTemplate>
+  );
+}

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -19,6 +19,11 @@ export type BioFrontmatter = {
   now?: string;
 };
 
+export type AboutFrontmatter = {
+  title?: string;
+  description?: string;
+};
+
 export type ResumeFrontmatter = {
   title?: string;
   description?: string;
@@ -103,6 +108,10 @@ async function compileFile<TFrontmatter extends Record<string, unknown>>(
 
 export const getBio = cache(async (): Promise<RenderedMdx<BioFrontmatter>> => {
   return compileFile<BioFrontmatter>(path.join(CONTENT_DIR, "bio.mdx"));
+});
+
+export const getAbout = cache(async (): Promise<RenderedMdx<AboutFrontmatter>> => {
+  return compileFile<AboutFrontmatter>(path.join(CONTENT_DIR, "about.mdx"));
 });
 
 export const getResume = cache(async (): Promise<RenderedMdx<ResumeFrontmatter>> => {


### PR DESCRIPTION
## Summary
- Adds the planned /about route as a static App Router page.
- Adds MDX-authored founder context for Alex Lucero with Loose Arrow Labs as the supporting studio identity.
- Extends the local content loader with getAbout() using the existing MDX pattern.

## Validation
- npm run lint
- npm run format:check
- npm run build

## Visual Summary
/about renders through the existing content page template and MDX renderer, matching the rest of the static-first content system.

Closes #17