### PR TITLE
[feat]content: extend project frontmatter model

### DIFF
--- a/content/projects/codex.mdx
+++ b/content/projects/codex.mdx
@@ -5,6 +5,13 @@ summary: "Indexing and retrieval tool for LLM's"
 featured: true
 status: "Phase 1: Complete"
 updated: "2026-02-27"
+repoOwner: "alucero270"
+repoName: "codex"
+repoPrimary: true
+evidence:
+  - label: "Repository"
+    href: "https://github.com/alucero270/codex"
+    type: "repo"
 ---
 
 ## Overview

--- a/content/projects/kittybot.mdx
+++ b/content/projects/kittybot.mdx
@@ -5,6 +5,13 @@ summary: "A fun project for my kids. A companion robot connected to our local LL
 featured: true
 status: "Phase 1"
 updated: "2026-02-27"
+repoOwner: "alucero270"
+repoName: "kittybot"
+repoPrimary: true
+evidence:
+  - label: "Repository"
+    href: "https://github.com/alucero270/kittybot"
+    type: "repo"
 ---
 
 ## Overview

--- a/content/projects/om606-signal-integration.mdx
+++ b/content/projects/om606-signal-integration.mdx
@@ -5,6 +5,14 @@ summary: "A motor swap experiment."
 featured: false
 status: "TODO: Add current status"
 updated: "2026-02-27"
+repoOwner: "alucero270"
+repoName: "Vehicle-Telemetry-and-Control-Node-VTCN-"
+repoPath: "om606-signal-integration"
+repoPrimary: true
+evidence:
+  - label: "Repository"
+    href: "https://github.com/alucero270/Vehicle-Telemetry-and-Control-Node-VTCN-"
+    type: "repo"
 ---
 
 ## Overview

--- a/content/projects/pantheon.mdx
+++ b/content/projects/pantheon.mdx
@@ -5,6 +5,13 @@ summary: "Homelab for AI, development, media, storage, etc."
 featured: false
 status: "An ongoing project"
 updated: "2026-02-27"
+repoOwner: "alucero270"
+repoName: "pantheon"
+repoPrimary: true
+evidence:
+  - label: "Repository"
+    href: "https://github.com/alucero270/pantheon"
+    type: "repo"
 ---
 
 ## Overview

--- a/content/projects/vtcn.mdx
+++ b/content/projects/vtcn.mdx
@@ -5,6 +5,13 @@ summary: "Telemetry project to receive sensor signals for data logging."
 featured: true
 status: "Phase 1"
 updated: "2026-02-27"
+repoOwner: "alucero270"
+repoName: "Vehicle-Telemetry-and-Control-Node-VTCN-"
+repoPrimary: true
+evidence:
+  - label: "Repository"
+    href: "https://github.com/alucero270/Vehicle-Telemetry-and-Control-Node-VTCN-"
+    type: "repo"
 ---
 
 ## Overview

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -33,6 +33,13 @@ export type ResumeFrontmatter = {
   github?: string;
 };
 
+export type ProjectEvidence = {
+  description?: string;
+  href: string;
+  label: string;
+  type?: "repo" | "diagram" | "screenshot" | "adr" | "validation" | "note";
+};
+
 export type ProjectFrontmatter = {
   title?: string;
   description?: string;
@@ -41,6 +48,14 @@ export type ProjectFrontmatter = {
   featured?: boolean;
   status?: string;
   updated?: string;
+  role?: string;
+  outcome?: string;
+  tech?: string[];
+  evidence?: ProjectEvidence[];
+  repoOwner?: string;
+  repoName?: string;
+  repoPath?: string;
+  repoPrimary?: boolean;
 };
 
 export type RenderedMdx<TFrontmatter> = {


### PR DESCRIPTION
## Summary
- Extends project frontmatter types with optional repo mapping fields, role/outcome/tech, and structured evidence metadata.
- Adds explicit repoOwner/repoName/repoPath/repoPrimary values where existing MDX repo links made the mapping safe.
- Adds repository evidence entries without forcing a full project content rewrite.

## Validation
- npm run lint
- npm run format:check
- npm run build

Closes #18