### PR TITLE
[feat]projects: add evidence link rendering

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,6 +87,7 @@ export default async function HomePage() {
   const [bio, featuredProjects] = await Promise.all([getBio(), getFeaturedProjects()]);
   const featuredProjectItems = featuredProjects.map((project) => ({
     actionLabel: "View details",
+    evidenceCount: project.evidence?.length,
     href: toInternalHref(`/projects/${project.slug}`),
     status: project.status,
     summary: project.summary,

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { MdxContent } from "@/components/mdx-content";
-import { ProjectDetailHeader } from "@/components/organisms";
+import { EngineeringEvidenceSection, ProjectDetailHeader } from "@/components/organisms";
 import { ProjectDetailTemplate } from "@/components/templates";
 import { getProjectBySlug, getProjectSlugs } from "@/lib/content";
 import { toInternalHref } from "@/lib/routing";
@@ -62,6 +62,11 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
         />
       }
     >
+      <EngineeringEvidenceSection
+        headingId="project-evidence-heading"
+        links={project.frontmatter.evidence}
+        title="Evidence"
+      />
       <MdxContent>{project.content}</MdxContent>
     </ProjectDetailTemplate>
   );

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
 export default async function ProjectsPage() {
   const projects = await getAllProjects();
   const projectItems = projects.map((project) => ({
+    evidenceCount: project.evidence?.length,
     href: toInternalHref(`/projects/${project.slug}`),
     status: project.status,
     summary: project.summary,

--- a/src/components/molecules/evidence-link-list.tsx
+++ b/src/components/molecules/evidence-link-list.tsx
@@ -6,6 +6,7 @@ export type EvidenceLink = {
   description?: string;
   href: string;
   label: string;
+  type?: string;
 };
 
 type EvidenceLinkListProps = {

--- a/src/components/molecules/project-card.tsx
+++ b/src/components/molecules/project-card.tsx
@@ -1,11 +1,14 @@
 import { ArrowForward } from "@mui/icons-material";
-import { Card, CardActions, CardContent, Typography } from "@mui/material";
+import { Card, CardActions, CardContent, Stack, Typography } from "@mui/material";
+
+import { MonoLabel } from "@/components/atoms";
 
 import { CTAGroup } from "./cta-group";
 import { ProjectMetaRow } from "./project-meta-row";
 
 export type ProjectCardData = {
   actionLabel?: string;
+  evidenceCount?: number;
   href: string;
   status?: string;
   summary: string;
@@ -19,6 +22,7 @@ type ProjectCardProps = ProjectCardData & {
 
 export function ProjectCard({
   actionLabel = "Open project",
+  evidenceCount,
   headingComponent = "h2",
   href,
   status,
@@ -26,6 +30,9 @@ export function ProjectCard({
   title,
   updated,
 }: ProjectCardProps) {
+  const evidenceLabel =
+    evidenceCount && evidenceCount > 1 ? `${evidenceCount} evidence links` : "1 evidence link";
+
   return (
     <Card component="article">
       <CardContent>
@@ -39,7 +46,10 @@ export function ProjectCard({
         <Typography color="text.secondary" sx={{ mb: 2 }}>
           {summary}
         </Typography>
-        <ProjectMetaRow status={status} updated={updated} />
+        <Stack spacing={1}>
+          <ProjectMetaRow status={status} updated={updated} />
+          {evidenceCount ? <MonoLabel>{evidenceLabel}</MonoLabel> : null}
+        </Stack>
       </CardContent>
       <CardActions>
         <CTAGroup

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -37,7 +37,7 @@ export type ProjectEvidence = {
   description?: string;
   href: string;
   label: string;
-  type?: "repo" | "diagram" | "screenshot" | "adr" | "validation" | "note";
+  type?: "repo" | "diagram" | "screenshot" | "adr" | "validation" | "note" | "pr" | "issue";
 };
 
 export type ProjectFrontmatter = {


### PR DESCRIPTION
## Summary
- Renders structured project evidence links on project detail pages when frontmatter provides them.
- Adds a small evidence-count hint to project cards without requiring evidence to exist.
- Extends evidence typing to include PR and issue links while keeping MDX as the narrative source.

## Validation
- npm run lint
- npm run format:check
- npm run build

Closes #19