### PR TITLE
[refactor]projects: redesign project index as proof surface

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -18,14 +18,24 @@ export default async function ProjectsPage() {
   const projectItems = projects.map((project) => ({
     evidenceCount: project.evidence?.length,
     href: toInternalHref(`/projects/${project.slug}`),
+    outcome: project.outcome,
+    repoLabel:
+      project.repoOwner && project.repoName
+        ? `${project.repoOwner}/${project.repoName}`
+        : undefined,
+    role: project.role,
     status: project.status,
     summary: project.summary,
+    tech: project.tech,
     title: project.title,
     updated: project.updated,
   }));
 
   return (
-    <ProjectIndexTemplate title="Projects">
+    <ProjectIndexTemplate
+      description="Project pages are treated as proof surfaces: authored context first, with metadata and evidence links where they are available."
+      title="Projects"
+    >
       <ProjectGrid projects={projectItems} />
     </ProjectIndexTemplate>
   );

--- a/src/components/molecules/project-card.tsx
+++ b/src/components/molecules/project-card.tsx
@@ -1,7 +1,7 @@
 import { ArrowForward } from "@mui/icons-material";
 import { Card, CardActions, CardContent, Stack, Typography } from "@mui/material";
 
-import { MonoLabel } from "@/components/atoms";
+import { MonoLabel, TechTag } from "@/components/atoms";
 
 import { CTAGroup } from "./cta-group";
 import { ProjectMetaRow } from "./project-meta-row";
@@ -10,8 +10,12 @@ export type ProjectCardData = {
   actionLabel?: string;
   evidenceCount?: number;
   href: string;
+  outcome?: string;
+  repoLabel?: string;
+  role?: string;
   status?: string;
   summary: string;
+  tech?: string[];
   title: string;
   updated?: string;
 };
@@ -25,8 +29,12 @@ export function ProjectCard({
   evidenceCount,
   headingComponent = "h2",
   href,
+  outcome,
+  repoLabel,
+  role,
   status,
   summary,
+  tech = [],
   title,
   updated,
 }: ProjectCardProps) {
@@ -34,8 +42,8 @@ export function ProjectCard({
     evidenceCount && evidenceCount > 1 ? `${evidenceCount} evidence links` : "1 evidence link";
 
   return (
-    <Card component="article">
-      <CardContent>
+    <Card component="article" sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <CardContent sx={{ flexGrow: 1 }}>
         <Typography
           component={headingComponent}
           variant="h3"
@@ -46,8 +54,18 @@ export function ProjectCard({
         <Typography color="text.secondary" sx={{ mb: 2 }}>
           {summary}
         </Typography>
-        <Stack spacing={1}>
+        <Stack spacing={1.25}>
           <ProjectMetaRow status={status} updated={updated} />
+          {role ? <Typography color="text.secondary">Role: {role}</Typography> : null}
+          {outcome ? <Typography color="text.secondary">Outcome: {outcome}</Typography> : null}
+          {tech.length > 0 ? (
+            <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+              {tech.map((tag) => (
+                <TechTag key={tag} label={tag} />
+              ))}
+            </Stack>
+          ) : null}
+          {repoLabel ? <MonoLabel>{repoLabel}</MonoLabel> : null}
           {evidenceCount ? <MonoLabel>{evidenceLabel}</MonoLabel> : null}
         </Stack>
       </CardContent>

--- a/src/components/organisms/project-grid.tsx
+++ b/src/components/organisms/project-grid.tsx
@@ -17,7 +17,7 @@ export function ProjectGrid({ headingComponent = "h2", projects }: ProjectGridPr
   return (
     <Grid container spacing={2.5}>
       {projects.map((project) => (
-        <Grid key={project.href} size={{ xs: 12, md: 6 }}>
+        <Grid key={project.href} size={{ xs: 12, md: 6, lg: 4 }}>
           <ProjectCard {...project} headingComponent={headingComponent} />
         </Grid>
       ))}

--- a/src/components/templates/project-index-template.tsx
+++ b/src/components/templates/project-index-template.tsx
@@ -1,19 +1,27 @@
-import { Stack } from "@mui/material";
+import { Stack, Typography } from "@mui/material";
 import type { ReactNode } from "react";
 
 import { SectionHeading } from "@/components/atoms";
 
 type ProjectIndexTemplateProps = {
   children: ReactNode;
+  description?: string;
   title: string;
 };
 
-export function ProjectIndexTemplate({ children, title }: ProjectIndexTemplateProps) {
+export function ProjectIndexTemplate({ children, description, title }: ProjectIndexTemplateProps) {
   return (
     <Stack spacing={3.5}>
-      <SectionHeading component="h1" variant="h1">
-        {title}
-      </SectionHeading>
+      <Stack spacing={1.5}>
+        <SectionHeading component="h1" variant="h1">
+          {title}
+        </SectionHeading>
+        {description ? (
+          <Typography color="text.secondary" sx={{ maxWidth: 760 }}>
+            {description}
+          </Typography>
+        ) : null}
+      </Stack>
       {children}
     </Stack>
   );


### PR DESCRIPTION
## Summary
- Reframes the project index as a proof surface with a concise description.
- Enhances project cards with available repo/evidence metadata while preserving MDX ordering and source data.
- Keeps the layout responsive and static, with no live GitHub dependency.

## Validation
- npm run lint
- npm run format:check
- npm run build

## Visual Summary
Project cards now scan as case-study/proof summaries with title, summary, status, updated date, repo label, evidence count, and detail link when data exists.

Closes #20