### PR TITLE
[refactor]projects: redesign project detail header

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -51,12 +51,23 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
     notFound();
   }
 
+  const repoLabel =
+    project.frontmatter.repoOwner && project.frontmatter.repoName
+      ? `${project.frontmatter.repoOwner}/${project.frontmatter.repoName}`
+      : undefined;
+
   return (
     <ProjectDetailTemplate
       header={
         <ProjectDetailHeader
           backHref={toInternalHref("/projects")}
+          evidenceCount={project.frontmatter.evidence?.length}
+          outcome={project.frontmatter.outcome}
+          repoLabel={repoLabel}
+          role={project.frontmatter.role}
           status={project.frontmatter.status}
+          summary={project.frontmatter.summary ?? project.frontmatter.description}
+          tech={project.frontmatter.tech}
           title={project.frontmatter.title ?? slug}
           updated={project.frontmatter.updated}
         />

--- a/src/components/organisms/project-detail-header.tsx
+++ b/src/components/organisms/project-detail-header.tsx
@@ -1,22 +1,37 @@
 import { ArrowBack } from "@mui/icons-material";
-import { Box } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 
-import { SectionHeading } from "@/components/atoms";
+import { MonoLabel, SectionHeading, TechTag } from "@/components/atoms";
 import { CTAGroup, ProjectMetaRow } from "@/components/molecules";
 
 type ProjectDetailHeaderProps = {
   backHref: string;
+  evidenceCount?: number;
+  outcome?: string;
+  repoLabel?: string;
+  role?: string;
   status?: string;
+  summary?: string;
+  tech?: string[];
   title: string;
   updated?: string;
 };
 
 export function ProjectDetailHeader({
   backHref,
+  evidenceCount,
+  outcome,
+  repoLabel,
+  role,
   status,
+  summary,
+  tech = [],
   title,
   updated,
 }: ProjectDetailHeaderProps) {
+  const evidenceLabel =
+    evidenceCount && evidenceCount > 1 ? `${evidenceCount} evidence links` : "1 evidence link";
+
   return (
     <Box component="header">
       <Box sx={{ mb: 1.5 }}>
@@ -33,7 +48,25 @@ export function ProjectDetailHeader({
       <SectionHeading component="h1" variant="h1" gutterBottom>
         {title}
       </SectionHeading>
-      <ProjectMetaRow status={status} updated={updated} />
+      {summary ? (
+        <Typography color="text.secondary" sx={{ maxWidth: 820, mb: 2 }}>
+          {summary}
+        </Typography>
+      ) : null}
+      <Stack spacing={1.25}>
+        <ProjectMetaRow status={status} updated={updated} />
+        {role ? <Typography color="text.secondary">Role: {role}</Typography> : null}
+        {outcome ? <Typography color="text.secondary">Outcome: {outcome}</Typography> : null}
+        {tech.length > 0 ? (
+          <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+            {tech.map((tag) => (
+              <TechTag key={tag} label={tag} />
+            ))}
+          </Stack>
+        ) : null}
+        {repoLabel ? <MonoLabel>{repoLabel}</MonoLabel> : null}
+        {evidenceCount ? <MonoLabel>{evidenceLabel}</MonoLabel> : null}
+      </Stack>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- Expands project detail headers with summary, status, updated date, repo label, evidence count, and optional role/outcome/tech metadata.
- Keeps static generation from MDX slugs unchanged.
- Leaves authored MDX content below the structured header.

## Validation
- npm run lint
- npm run format:check
- npm run build

Closes #21