### PR TITLE
[feat]github: add allowlisted repo config

### DIFF
--- a/src/lib/github-config.ts
+++ b/src/lib/github-config.ts
@@ -1,0 +1,56 @@
+export type GitHubRepoConfig = {
+  projectSlugs?: string[];
+  repoName: string;
+  repoOwner: string;
+  repoPath?: string;
+  repoPrimary?: boolean;
+};
+
+export const githubRepoAllowlist = [
+  {
+    projectSlugs: ["codex"],
+    repoName: "codex",
+    repoOwner: "alucero270",
+    repoPrimary: true,
+  },
+  {
+    projectSlugs: ["kittybot"],
+    repoName: "kittybot",
+    repoOwner: "alucero270",
+    repoPrimary: true,
+  },
+  {
+    projectSlugs: ["vtcn"],
+    repoName: "Vehicle-Telemetry-and-Control-Node-VTCN-",
+    repoOwner: "alucero270",
+    repoPrimary: true,
+  },
+  {
+    projectSlugs: ["om606-signal-integration"],
+    repoName: "Vehicle-Telemetry-and-Control-Node-VTCN-",
+    repoOwner: "alucero270",
+    repoPath: "om606-signal-integration",
+    repoPrimary: false,
+  },
+  {
+    projectSlugs: ["pantheon"],
+    repoName: "pantheon",
+    repoOwner: "alucero270",
+    repoPrimary: true,
+  },
+] satisfies GitHubRepoConfig[];
+
+export function toGitHubRepoKey(repoOwner: string, repoName: string): string {
+  return `${repoOwner.toLowerCase()}/${repoName.toLowerCase()}`;
+}
+
+export function isGitHubRepoAllowed(repoOwner: string, repoName: string): boolean {
+  const repoKey = toGitHubRepoKey(repoOwner, repoName);
+  return githubRepoAllowlist.some(
+    (repo) => toGitHubRepoKey(repo.repoOwner, repo.repoName) === repoKey,
+  );
+}
+
+export function getGitHubReposForProject(projectSlug: string): GitHubRepoConfig[] {
+  return githubRepoAllowlist.filter((repo) => repo.projectSlugs?.includes(projectSlug));
+}


### PR DESCRIPTION
## Summary
- Adds a typed local GitHub repo allowlist config.
- Supports repoOwner, repoName, optional repoPath, optional repoPrimary, and project slug mapping.
- Adds helper functions for repo keys, allowlist checks, and project-to-repo lookup without fetching GitHub data.

## Validation
- npm run lint
- npm run format:check
- npm run build

Closes #23