### PR TITLE
[feat]home: render GitHub-backed working-now activity

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,11 @@ import {
 import { HomeTemplate } from "@/components/templates";
 import type { ActivityItemData, EvidenceLink } from "@/components/molecules";
 import { getBio, getFeaturedProjects } from "@/lib/content";
+import {
+  fetchAllowlistedGitHubRepos,
+  getFilteredGitHubActivity,
+  type GitHubActivityItem,
+} from "@/lib/github";
 import { toInternalHref } from "@/lib/routing";
 import { siteConfig } from "@/lib/site";
 
@@ -83,8 +88,38 @@ const workingNowFallbackItems: ActivityItemData[] = [
   },
 ];
 
+function toWorkingNowActivityItem(activityItem: GitHubActivityItem): ActivityItemData {
+  return {
+    href: activityItem.url,
+    label: activityItem.label,
+    summary: activityItem.summary,
+    title: activityItem.title,
+  };
+}
+
+async function getWorkingNowItems(): Promise<ActivityItemData[]> {
+  if (process.env.STATIC_EXPORT === "true") {
+    return workingNowFallbackItems;
+  }
+
+  try {
+    const repos = await fetchAllowlistedGitHubRepos(undefined, { commitLimit: 8 });
+    const activityItems = getFilteredGitHubActivity(repos, { limit: 3 }).map(
+      toWorkingNowActivityItem,
+    );
+
+    return activityItems.length > 0 ? activityItems : workingNowFallbackItems;
+  } catch {
+    return workingNowFallbackItems;
+  }
+}
+
 export default async function HomePage() {
-  const [bio, featuredProjects] = await Promise.all([getBio(), getFeaturedProjects()]);
+  const [bio, featuredProjects, workingNowItems] = await Promise.all([
+    getBio(),
+    getFeaturedProjects(),
+    getWorkingNowItems(),
+  ]);
   const featuredProjectItems = featuredProjects.map((project) => ({
     actionLabel: "View details",
     evidenceCount: project.evidence?.length,
@@ -159,7 +194,7 @@ export default async function HomePage() {
         <WorkingNowCard
           key="working-now"
           headingId="working-now-heading"
-          items={workingNowFallbackItems}
+          items={workingNowItems}
           summary={
             bio.frontmatter.now ??
             "TODO: Add current work focus in /content/bio.mdx frontmatter `now`."


### PR DESCRIPTION
## Summary
- Wire the homepage Working Now section to allowlisted, filtered GitHub activity when available.
- Keep the local Working Now items as the fallback for API failure, no usable activity, and static export mode.
- Leave the existing WorkingNow organism API intact so GitHub remains an optional enhancement.

## Validation
- npm run lint
- npm run format:check
- npm run build
- STATIC_EXPORT=true npm run build

## Notes
- Static export mode bypasses live GitHub fetching and renders local fallback activity.
- GitHub activity remains limited and filtered by the existing allowlist/filter helpers.
