### PR TITLE
[feat]projects: render repo freshness metadata

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { MdxContent } from "@/components/mdx-content";
 import { EngineeringEvidenceSection, ProjectDetailHeader } from "@/components/organisms";
 import { ProjectDetailTemplate } from "@/components/templates";
 import { getProjectBySlug, getProjectSlugs } from "@/lib/content";
+import { fetchProjectGitHubFreshness } from "@/lib/github";
 import { toInternalHref } from "@/lib/routing";
 
 type ProjectPageProps = {
@@ -45,7 +46,10 @@ export async function generateMetadata({ params }: ProjectPageProps): Promise<Me
 
 export default async function ProjectPage({ params }: ProjectPageProps) {
   const { slug } = await params;
-  const project = await getProjectBySlug(slug);
+  const [project, repoFreshness] = await Promise.all([
+    getProjectBySlug(slug),
+    fetchProjectGitHubFreshness(slug),
+  ]);
 
   if (!project) {
     notFound();
@@ -63,6 +67,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
           backHref={toInternalHref("/projects")}
           evidenceCount={project.frontmatter.evidence?.length}
           outcome={project.frontmatter.outcome}
+          repoFreshness={repoFreshness ?? undefined}
           repoLabel={repoLabel}
           role={project.frontmatter.role}
           status={project.frontmatter.status}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { ProjectGrid } from "@/components/organisms";
 import { ProjectIndexTemplate } from "@/components/templates";
 import { getAllProjects } from "@/lib/content";
+import { fetchGitHubFreshnessByProjectSlug } from "@/lib/github";
 import { toInternalHref } from "@/lib/routing";
 
 export const dynamic = "force-static";
@@ -14,7 +15,10 @@ export const metadata: Metadata = {
 };
 
 export default async function ProjectsPage() {
-  const projects = await getAllProjects();
+  const [projects, repoFreshnessBySlug] = await Promise.all([
+    getAllProjects(),
+    fetchGitHubFreshnessByProjectSlug(),
+  ]);
   const projectItems = projects.map((project) => ({
     evidenceCount: project.evidence?.length,
     href: toInternalHref(`/projects/${project.slug}`),
@@ -23,6 +27,7 @@ export default async function ProjectsPage() {
       project.repoOwner && project.repoName
         ? `${project.repoOwner}/${project.repoName}`
         : undefined,
+    repoFreshness: repoFreshnessBySlug.get(project.slug),
     role: project.role,
     status: project.status,
     summary: project.summary,

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -7,3 +7,5 @@ export type { EvidenceLink } from "./evidence-link-list";
 export { ProjectCard } from "./project-card";
 export type { ProjectCardData } from "./project-card";
 export { ProjectMetaRow } from "./project-meta-row";
+export { RepoFreshnessBadge } from "./repo-freshness-badge";
+export type { RepoFreshnessData } from "./repo-freshness-badge";

--- a/src/components/molecules/project-card.tsx
+++ b/src/components/molecules/project-card.tsx
@@ -5,6 +5,7 @@ import { MonoLabel, TechTag } from "@/components/atoms";
 
 import { CTAGroup } from "./cta-group";
 import { ProjectMetaRow } from "./project-meta-row";
+import { RepoFreshnessBadge, type RepoFreshnessData } from "./repo-freshness-badge";
 
 export type ProjectCardData = {
   actionLabel?: string;
@@ -12,6 +13,7 @@ export type ProjectCardData = {
   href: string;
   outcome?: string;
   repoLabel?: string;
+  repoFreshness?: RepoFreshnessData;
   role?: string;
   status?: string;
   summary: string;
@@ -30,6 +32,7 @@ export function ProjectCard({
   headingComponent = "h2",
   href,
   outcome,
+  repoFreshness,
   repoLabel,
   role,
   status,
@@ -66,6 +69,7 @@ export function ProjectCard({
             </Stack>
           ) : null}
           {repoLabel ? <MonoLabel>{repoLabel}</MonoLabel> : null}
+          <RepoFreshnessBadge freshness={repoFreshness} />
           {evidenceCount ? <MonoLabel>{evidenceLabel}</MonoLabel> : null}
         </Stack>
       </CardContent>

--- a/src/components/molecules/repo-freshness-badge.tsx
+++ b/src/components/molecules/repo-freshness-badge.tsx
@@ -1,0 +1,25 @@
+import { Stack } from "@mui/material";
+
+import { MonoLabel } from "@/components/atoms";
+
+export type RepoFreshnessData = {
+  label: string;
+  primaryLanguage?: string;
+};
+
+type RepoFreshnessBadgeProps = {
+  freshness?: RepoFreshnessData;
+};
+
+export function RepoFreshnessBadge({ freshness }: RepoFreshnessBadgeProps) {
+  if (!freshness) {
+    return null;
+  }
+
+  return (
+    <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" alignItems="center">
+      <MonoLabel>{freshness.label}</MonoLabel>
+      {freshness.primaryLanguage ? <MonoLabel>{freshness.primaryLanguage}</MonoLabel> : null}
+    </Stack>
+  );
+}

--- a/src/components/organisms/project-detail-header.tsx
+++ b/src/components/organisms/project-detail-header.tsx
@@ -2,12 +2,18 @@ import { ArrowBack } from "@mui/icons-material";
 import { Box, Stack, Typography } from "@mui/material";
 
 import { MonoLabel, SectionHeading, TechTag } from "@/components/atoms";
-import { CTAGroup, ProjectMetaRow } from "@/components/molecules";
+import {
+  CTAGroup,
+  ProjectMetaRow,
+  RepoFreshnessBadge,
+  type RepoFreshnessData,
+} from "@/components/molecules";
 
 type ProjectDetailHeaderProps = {
   backHref: string;
   evidenceCount?: number;
   outcome?: string;
+  repoFreshness?: RepoFreshnessData;
   repoLabel?: string;
   role?: string;
   status?: string;
@@ -21,6 +27,7 @@ export function ProjectDetailHeader({
   backHref,
   evidenceCount,
   outcome,
+  repoFreshness,
   repoLabel,
   role,
   status,
@@ -65,6 +72,7 @@ export function ProjectDetailHeader({
           </Stack>
         ) : null}
         {repoLabel ? <MonoLabel>{repoLabel}</MonoLabel> : null}
+        <RepoFreshnessBadge freshness={repoFreshness} />
         {evidenceCount ? <MonoLabel>{evidenceLabel}</MonoLabel> : null}
       </Stack>
     </Box>

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,4 +1,5 @@
 import {
+  getGitHubReposForProject,
   githubRepoAllowlist,
   isGitHubRepoAllowed,
   toGitHubRepoKey,
@@ -64,6 +65,15 @@ export type GitHubActivityItem = {
   repoUrl: string;
   summary?: string;
   title: string;
+  url: string;
+};
+
+export type GitHubRepoFreshness = {
+  label: string;
+  occurredAt: string;
+  primaryLanguage?: string;
+  repoName: string;
+  repoOwner: string;
   url: string;
 };
 
@@ -241,6 +251,21 @@ function toDateWeight(value: string | undefined): number {
   return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
 }
 
+function formatGitHubDate(value: string): string | null {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(parsed);
+}
+
 function getLatestUsefulCommit(repo: NormalizedGitHubRepo): NormalizedGitHubCommit | null {
   const usefulCommits = repo.latestCommits
     .filter((commit) => isUsefulGitHubCommit(commit))
@@ -287,4 +312,103 @@ export function getFilteredGitHubActivity(
     .filter((item): item is GitHubActivityItem => Boolean(item))
     .sort((a, b) => toDateWeight(b.occurredAt) - toDateWeight(a.occurredAt))
     .slice(0, limit);
+}
+
+export function getGitHubRepoFreshness(repo: NormalizedGitHubRepo): GitHubRepoFreshness | null {
+  const occurredAt = repo.pushedAt ?? repo.updatedAt;
+
+  if (!occurredAt) {
+    return null;
+  }
+
+  const formattedDate = formatGitHubDate(occurredAt);
+
+  if (!formattedDate) {
+    return null;
+  }
+
+  return {
+    label: `${repo.pushedAt ? "Repo pushed" : "Repo updated"} ${formattedDate}`,
+    occurredAt,
+    primaryLanguage: repo.primaryLanguage,
+    repoName: repo.repoName,
+    repoOwner: repo.repoOwner,
+    url: repo.url,
+  };
+}
+
+function selectGitHubRepoFreshness(repos: NormalizedGitHubRepo[]): GitHubRepoFreshness | null {
+  const freshnessCandidates = repos
+    .map((repo) => ({
+      freshness: getGitHubRepoFreshness(repo),
+      repo,
+    }))
+    .filter(
+      (candidate): candidate is { freshness: GitHubRepoFreshness; repo: NormalizedGitHubRepo } =>
+        Boolean(candidate.freshness),
+    )
+    .sort((a, b) => {
+      if (a.repo.repoPrimary !== b.repo.repoPrimary) {
+        return b.repo.repoPrimary ? 1 : -1;
+      }
+
+      return toDateWeight(b.freshness.occurredAt) - toDateWeight(a.freshness.occurredAt);
+    });
+
+  return freshnessCandidates[0]?.freshness ?? null;
+}
+
+export async function fetchProjectGitHubFreshness(
+  projectSlug: string,
+): Promise<GitHubRepoFreshness | null> {
+  if (process.env.STATIC_EXPORT === "true") {
+    return null;
+  }
+
+  const configs = getGitHubReposForProject(projectSlug);
+
+  if (configs.length === 0) {
+    return null;
+  }
+
+  try {
+    const repos = await fetchAllowlistedGitHubRepos(configs, { commitLimit: 1 });
+
+    return selectGitHubRepoFreshness(repos);
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchGitHubFreshnessByProjectSlug(
+  configs: GitHubRepoConfig[] = githubRepoAllowlist,
+): Promise<Map<string, GitHubRepoFreshness>> {
+  const freshnessBySlug = new Map<string, GitHubRepoFreshness>();
+
+  if (process.env.STATIC_EXPORT === "true") {
+    return freshnessBySlug;
+  }
+
+  try {
+    const repos = await fetchAllowlistedGitHubRepos(configs, { commitLimit: 1 });
+    const reposBySlug = new Map<string, NormalizedGitHubRepo[]>();
+
+    for (const repo of repos) {
+      for (const projectSlug of repo.projectSlugs) {
+        reposBySlug.set(projectSlug, [...(reposBySlug.get(projectSlug) ?? []), repo]);
+      }
+    }
+
+    for (const [projectSlug, projectRepos] of reposBySlug.entries()) {
+      const freshness = selectGitHubRepoFreshness(projectRepos);
+
+      if (freshness) {
+        freshnessBySlug.set(projectSlug, freshness);
+      }
+    }
+  } catch {
+    return freshnessBySlug;
+  }
+
+  return freshnessBySlug;
 }


### PR DESCRIPTION
## Summary
- Add a compact repo freshness badge for project cards and detail headers.
- Source freshness only from explicit allowlisted project-to-repo mappings.
- Keep authored MDX `updated` metadata visible as the durable fallback while GitHub freshness decorates it.

## Validation
- npm run lint
- npm run format:check
- npm run build
- STATIC_EXPORT=true npm run build

## Notes
- Static export mode returns no live freshness metadata, so project pages keep rendering from local MDX fields.
- GitHub fetch failures return empty freshness data and do not block rendering.
