### PR TITLE
[style] global: align base CSS with dark-first theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,7 +16,19 @@ html {
 
 body {
   min-height: 100vh;
-  background: #080a0f;
+  background-color: #080a0f;
+  background-image:
+    radial-gradient(ellipse 80% 48% at 50% -12%, rgba(155, 124, 255, 0.09), transparent 62%),
+    linear-gradient(rgba(166, 176, 195, 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(166, 176, 195, 0.055) 1px, transparent 1px);
+  background-position:
+    center top,
+    -1px -1px,
+    -1px -1px;
+  background-size:
+    auto,
+    64px 64px,
+    64px 64px;
   color: #f6f7fb;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Summary

Aligns the global CSS foundation with the dark-first Loose Arrow Labs direction.

## Changes

- Replaces the flat body background with a near-black base color plus a restrained violet vignette.
- Adds a subtle technical grid at the document level so component styles can remain MUI-driven.
- Keeps the existing minimal reset and accessible focus-visible outline.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`

## Notes

This is intentionally scoped to `src/app/globals.css` for issue #5. Broader MUI/component visual polish remains in the later theme port issue.