### PR TITLE
[style] layout: update metadata and font direction

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
-import { JetBrains_Mono, Source_Sans_3, Space_Grotesk } from "next/font/google";
+import { Inter, JetBrains_Mono, Space_Grotesk } from "next/font/google";
 import "./globals.css";
 
 import { SiteShell } from "@/components/site-shell";
 import { ThemeRegistry } from "@/components/theme-registry";
 import { siteConfig } from "@/lib/site";
 
-const sourceSans = Source_Sans_3({
+const inter = Inter({
   variable: "--font-body",
   subsets: ["latin"],
   display: "swap",
@@ -50,7 +50,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${sourceSans.variable} ${spaceGrotesk.variable} ${jetbrainsMono.variable}`}
+      className={`${inter.variable} ${spaceGrotesk.variable} ${jetbrainsMono.variable}`}
     >
       <body>
         <ThemeRegistry>

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -3,7 +3,7 @@ export const siteConfig = {
   studioName: "Loose Arrow Labs",
   siteTitle: "Alex Lucero | Loose Arrow Labs",
   siteDescription:
-    "Founder-led technical portfolio for Alex Lucero, with Loose Arrow Labs as the studio identity for practical software, automation, and AI integration work.",
+    "Technical portfolio for Alex Lucero, with Loose Arrow Labs as the studio identity for practical software, embedded systems, automation, and physical integration work.",
   email: "TODO_ADD_EMAIL",
   github: "TODO_ADD_GITHUB_URL",
   linkedin: "TODO_ADD_LINKEDIN_URL",


### PR DESCRIPTION
## Summary

Updates the root metadata and font direction for the founder-led technical authority positioning.

## Changes

- Switches body text from Source Sans 3 to Inter while keeping Space Grotesk for geometric headings and JetBrains Mono for technical accents.
- Updates the shared site description so metadata presents Alex Lucero first, with Loose Arrow Labs as the studio identity for practical software, embedded systems, automation, and physical integration work.
- Preserves the existing App Router layout and ThemeRegistry pattern.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`

## Stack

This PR is stacked on #60 for the issue #5 global CSS foundation.