### PR TITLE
[refactor] shell: establish founder-led header and footer

### DIFF
--- a/src/components/site-shell.tsx
+++ b/src/components/site-shell.tsx
@@ -42,9 +42,15 @@ export function SiteShell({ children }: SiteShellProps) {
               <Typography
                 component="span"
                 variant="caption"
-                sx={{ color: "text.secondary", letterSpacing: 0, textTransform: "uppercase" }}
+                sx={{
+                  color: "text.secondary",
+                  fontFamily: "var(--font-code)",
+                  fontSize: "0.72rem",
+                  letterSpacing: 0,
+                  textTransform: "uppercase",
+                }}
               >
-                {siteConfig.studioName}
+                {siteConfig.studioName} / {siteConfig.studioRole}
               </Typography>
             </Stack>
             <Stack
@@ -80,8 +86,8 @@ export function SiteShell({ children }: SiteShellProps) {
               {new Date().getFullYear()} {siteConfig.ownerName}
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              {siteConfig.studioName} is the studio layer for selected software, automation, and AI
-              integration work.
+              {siteConfig.studioName} is the studio identity for practical software, embedded
+              integration, automation, and tools Alex can inspect and maintain.
             </Typography>
           </Stack>
         </Container>

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,6 +1,7 @@
 export const siteConfig = {
   ownerName: "Alex Lucero",
   studioName: "Loose Arrow Labs",
+  studioRole: "Systems studio",
   siteTitle: "Alex Lucero | Loose Arrow Labs",
   siteDescription:
     "Technical portfolio for Alex Lucero, with Loose Arrow Labs as the studio identity for practical software, embedded systems, automation, and physical integration work.",


### PR DESCRIPTION
## Summary

Refines the global shell so Alex Lucero remains the primary trust anchor and Loose Arrow Labs is clearly secondary studio identity.

## Changes

- Adds a compact `Systems studio` descriptor for Loose Arrow Labs in shared site config.
- Updates the header lockup so Alex Lucero remains primary and the studio label reads as supporting technical context.
- Rewrites footer copy toward practical software, embedded integration, automation, and maintainable tools without agency-style claims.
- Keeps existing Home, Projects, About, Resume, and Contact navigation intact.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`

## Stack

This PR is stacked on #61 for issue #6.