### PR TITLE
[style] theme: port Claude redesign visual language into MUI

### DIFF
--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -138,8 +138,9 @@ Implemented GitHub behavior:
 - muted borders
 - geometric heading font direction
 - 8px radius
+- denser technical card treatment, crisp borders, and compact mono metadata
 
-`src/app/globals.css` currently defines base reset styles, dark color-scheme behavior, and accessible focus-visible styling.
+`src/app/globals.css` currently defines base reset styles, dark color-scheme behavior, a restrained technical grid/vignette backdrop, and accessible focus-visible styling.
 
 `src/components/site-shell.tsx` owns the global header, navigation, main container, and footer. The shell now makes Alex Lucero primary and Loose Arrow Labs secondary.
 
@@ -151,6 +152,7 @@ Reusable UI now exists under:
 - `src/components/templates`
 
 The homepage uses the reusable section/template structure for hero, what-we-do, selected work, build philosophy, proof, working-now fallback, about preview, and contact CTA sections.
+The homepage now ports the Claude redesign visual direction through existing MUI components: a two-column authority hero with a curated signal panel, a compact signal strip after the hero, denser project/activity cards, and explicit live/curated signal labels backed by either GitHub data or local fallback content.
 
 The project index and detail pages use shared project cards, metadata rows, evidence link rendering, project grid, project index template, and project detail header components.
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,8 @@ import {
   ContactCTASection,
   EngineeringEvidenceSection,
   SelectedWorkSection,
+  SignalStripSection,
+  type SignalStripItem,
   WhatWeDoSection,
   type WhatWeDoItem,
   WorkingNowCard,
@@ -22,7 +24,6 @@ import {
   type GitHubActivityItem,
 } from "@/lib/github";
 import { toInternalHref } from "@/lib/routing";
-import { siteConfig } from "@/lib/site";
 
 export const dynamic = "force-static";
 
@@ -33,19 +34,38 @@ export const metadata: Metadata = {
 
 const whatWeDoItems: WhatWeDoItem[] = [
   {
-    title: "Systems structuring",
+    title: "Embedded + systems integration",
     description:
-      "Turn ambiguous technical work into explicit boundaries, data shapes, implementation paths, and validation steps.",
+      "Connect software to physical systems through explicit interfaces, telemetry, and validation steps.",
   },
   {
-    title: "AI integration",
+    title: "Robotics + prototype builds",
     description:
-      "Use LLMs where they improve retrieval, automation, and operator flow without making live AI the source of truth.",
+      "Build and stabilize systems that move, respond, and expose behavior clearly enough to test.",
   },
   {
-    title: "Supportable prototypes",
+    title: "Software + AI-assisted tools",
     description:
-      "Build small, inspectable slices with enough documentation, tests, and tradeoff notes to keep moving after the demo.",
+      "Use practical software and selective AI assistance for diagnostics, workflows, and system understanding.",
+  },
+];
+
+const signalStripItems: SignalStripItem[] = [
+  {
+    label: "Embedded + integration",
+    description: "Sensors, controllers, and software under real constraints.",
+  },
+  {
+    label: "Robotics + automation",
+    description: "Control logic, state behavior, and physical iteration.",
+  },
+  {
+    label: "Software tooling",
+    description: "Diagnostics, data flow, and maintainable internal utilities.",
+  },
+  {
+    label: "Inspectable proof",
+    description: "Repos, notes, diagrams, validation logs, and written tradeoffs.",
   },
 ];
 
@@ -69,19 +89,19 @@ const buildPrinciples: BuildPrinciple[] = [
 
 const workingNowFallbackItems: ActivityItemData[] = [
   {
-    label: "Current focus",
+    label: "Curated focus",
     summary:
       "Personal retrieval and documentation workflows for project decisions, procedures, and engineering notes.",
     title: "Codex",
   },
   {
-    label: "Systems integration",
+    label: "Curated system",
     summary:
       "Companion robot planning, service boundaries, and hardware/software interface contracts.",
     title: "KittyBot",
   },
   {
-    label: "Embedded Linux",
+    label: "Curated system",
     summary:
       "Telemetry platform work around sensor input, framing, persistence, and validation loops.",
     title: "VTCN",
@@ -91,7 +111,7 @@ const workingNowFallbackItems: ActivityItemData[] = [
 function toWorkingNowActivityItem(activityItem: GitHubActivityItem): ActivityItemData {
   return {
     href: activityItem.url,
-    label: activityItem.label,
+    label: `Live signal / ${activityItem.label}`,
     summary: activityItem.summary,
     title: activityItem.title,
   };
@@ -155,23 +175,29 @@ export default async function HomePage() {
           ctas={[
             {
               href: "#featured-projects-heading",
-              label: "Selected work",
+              label: "View current work",
               variant: "contained",
             },
             {
               href: toInternalHref("/contact"),
-              label: "Contact",
+              label: "Start a conversation",
               variant: "outlined",
             },
           ]}
-          eyebrow={`${siteConfig.ownerName} / ${siteConfig.studioName}`}
+          eyebrow="Active systems / prototype builds / engineering in progress"
           headingId="home-bio-heading"
-          summary="I build practical software, automation, and systems-integration projects with an emphasis on reliability, documentation, and proof you can inspect."
-          techTags={["Next.js", "TypeScript", "MUI", "MDX"]}
+          summary="Loose Arrow Labs is the studio identity for hands-on engineering across software, embedded systems, automation, and physical integration."
+          techTags={[
+            "Embedded systems & integration",
+            "Robotics & prototype builds",
+            "Software tooling & diagnostics",
+            "Testable system design",
+          ]}
           title={bio.frontmatter.title ?? "Alex Lucero"}
         >
           <MdxContent>{bio.content}</MdxContent>
         </AuthorityHero>,
+        <SignalStripSection key="signal-strip" items={signalStripItems} />,
         <WhatWeDoSection key="what-we-do" headingId="what-we-do-heading" items={whatWeDoItems} />,
         <SelectedWorkSection
           key="selected-work"

--- a/src/components/molecules/activity-item.tsx
+++ b/src/components/molecules/activity-item.tsx
@@ -1,4 +1,4 @@
-import { Stack, Typography } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 
 import { ExternalLink, MonoLabel } from "@/components/atoms";
 
@@ -11,8 +11,33 @@ export type ActivityItemData = {
 
 export function ActivityItem({ href, label, summary, title }: ActivityItemData) {
   return (
-    <Stack spacing={0.5}>
-      {label ? <MonoLabel>{label}</MonoLabel> : null}
+    <Stack
+      spacing={0.75}
+      sx={{
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 1,
+        backgroundColor: "background.paper",
+        p: 2,
+        position: "relative",
+      }}
+    >
+      <Box
+        aria-hidden
+        sx={{
+          backgroundColor: label?.toLowerCase().includes("live") ? "#7BD88F" : "primary.main",
+          borderRadius: "999px",
+          boxShadow: label?.toLowerCase().includes("live")
+            ? "0 0 0 3px rgba(123, 216, 143, 0.16)"
+            : "0 0 0 3px rgba(155, 124, 255, 0.14)",
+          height: 6,
+          left: 16,
+          position: "absolute",
+          top: 17,
+          width: 6,
+        }}
+      />
+      {label ? <MonoLabel sx={{ pl: 2 }}>{label}</MonoLabel> : null}
       <Typography component="h3" variant="h3" sx={{ fontSize: "1.1rem" }}>
         {href ? <ExternalLink href={href}>{title}</ExternalLink> : title}
       </Typography>

--- a/src/components/molecules/project-card.tsx
+++ b/src/components/molecules/project-card.tsx
@@ -1,5 +1,5 @@
 import { ArrowForward } from "@mui/icons-material";
-import { Card, CardActions, CardContent, Stack, Typography } from "@mui/material";
+import { Box, Card, CardActions, CardContent, Stack, Typography } from "@mui/material";
 
 import { MonoLabel, TechTag } from "@/components/atoms";
 
@@ -46,6 +46,19 @@ export function ProjectCard({
 
   return (
     <Card component="article" sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <Box
+        sx={{
+          borderBottom: "1px solid",
+          borderColor: "divider",
+          display: "flex",
+          justifyContent: "space-between",
+          px: 2.5,
+          py: 1.25,
+        }}
+      >
+        <MonoLabel sx={{ color: "primary.main" }}>Curated project</MonoLabel>
+        {status ? <MonoLabel>{status}</MonoLabel> : null}
+      </Box>
       <CardContent sx={{ flexGrow: 1 }}>
         <Typography
           component={headingComponent}
@@ -58,7 +71,7 @@ export function ProjectCard({
           {summary}
         </Typography>
         <Stack spacing={1.25}>
-          <ProjectMetaRow status={status} updated={updated} />
+          <ProjectMetaRow updated={updated} />
           {role ? <Typography color="text.secondary">Role: {role}</Typography> : null}
           {outcome ? <Typography color="text.secondary">Outcome: {outcome}</Typography> : null}
           {tech.length > 0 ? (

--- a/src/components/molecules/repo-freshness-badge.tsx
+++ b/src/components/molecules/repo-freshness-badge.tsx
@@ -18,6 +18,7 @@ export function RepoFreshnessBadge({ freshness }: RepoFreshnessBadgeProps) {
 
   return (
     <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" alignItems="center">
+      <MonoLabel sx={{ color: "#7BD88F" }}>Live repo signal</MonoLabel>
       <MonoLabel>{freshness.label}</MonoLabel>
       {freshness.primaryLanguage ? <MonoLabel>{freshness.primaryLanguage}</MonoLabel> : null}
     </Stack>

--- a/src/components/organisms/authority-hero.tsx
+++ b/src/components/organisms/authority-hero.tsx
@@ -1,7 +1,7 @@
 import { Box, Stack, Typography } from "@mui/material";
 import type { ReactNode } from "react";
 
-import { SectionEyebrow, SectionHeading, TechTag } from "@/components/atoms";
+import { MonoLabel, SectionEyebrow, SectionHeading, TechTag } from "@/components/atoms";
 import { CTAGroup } from "@/components/molecules";
 
 type HeroCTA = {
@@ -30,27 +30,63 @@ export function AuthorityHero({
   title,
 }: AuthorityHeroProps) {
   return (
-    <Box component="section" aria-labelledby={headingId}>
-      <Stack spacing={2.5} sx={{ maxWidth: 880 }}>
+    <Box
+      component="section"
+      aria-labelledby={headingId}
+      sx={{
+        display: "grid",
+        gap: { xs: 4, md: 7 },
+        gridTemplateColumns: { xs: "1fr", md: "minmax(0, 1.05fr) minmax(320px, 0.85fr)" },
+        alignItems: "center",
+        py: { xs: 2, md: 3 },
+      }}
+    >
+      <Stack spacing={2.5}>
         {eyebrow ? <SectionEyebrow>{eyebrow}</SectionEyebrow> : null}
-        <SectionHeading id={headingId} component="h1" variant="h1">
+        <SectionHeading id={headingId} component="h1" variant="h1" sx={{ maxWidth: 860 }}>
           {title}
         </SectionHeading>
         {summary ? (
-          <Typography component="p" variant="h2" sx={{ color: "text.secondary", maxWidth: 760 }}>
+          <Typography
+            component="p"
+            variant="h2"
+            sx={{
+              color: "text.secondary",
+              fontFamily: "var(--font-body)",
+              fontSize: { xs: "1.25rem", md: "1.45rem" },
+              fontWeight: 400,
+              lineHeight: 1.45,
+              maxWidth: 760,
+            }}
+          >
             {summary}
           </Typography>
         ) : null}
         {ctas.length > 0 ? <CTAGroup actions={ctas} /> : null}
-        <Box sx={{ maxWidth: 760 }}>{children}</Box>
       </Stack>
-      {techTags.length > 0 ? (
-        <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ mt: 3 }}>
-          {techTags.map((tag) => (
-            <TechTag key={tag} label={tag} />
-          ))}
-        </Stack>
-      ) : null}
+
+      <Stack
+        spacing={2.25}
+        sx={{
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: 1,
+          backgroundColor: "background.paper",
+          backgroundImage:
+            "linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0))",
+          p: { xs: 2.5, md: 3 },
+        }}
+      >
+        <MonoLabel sx={{ color: "primary.main" }}>Curated profile signal</MonoLabel>
+        <Box>{children}</Box>
+        {techTags.length > 0 ? (
+          <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+            {techTags.map((tag) => (
+              <TechTag key={tag} label={tag} />
+            ))}
+          </Stack>
+        ) : null}
+      </Stack>
     </Box>
   );
 }

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -8,6 +8,8 @@ export { ProjectDetailHeader } from "./project-detail-header";
 export { ProjectGrid } from "./project-grid";
 export type { ProjectGridItem } from "./project-grid";
 export { SelectedWorkSection } from "./selected-work-section";
+export { SignalStripSection } from "./signal-strip-section";
+export type { SignalStripItem } from "./signal-strip-section";
 export { WhatWeDoSection } from "./what-we-do-section";
 export type { WhatWeDoItem } from "./what-we-do-section";
 export { WorkingNowCard } from "./working-now-card";

--- a/src/components/organisms/selected-work-section.tsx
+++ b/src/components/organisms/selected-work-section.tsx
@@ -22,7 +22,13 @@ export function SelectedWorkSection({
 }: SelectedWorkSectionProps) {
   return (
     <Box component="section" aria-labelledby={headingId}>
-      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2.5 }}>
+      <Stack
+        direction={{ xs: "column", md: "row" }}
+        justifyContent="space-between"
+        alignItems={{ xs: "flex-start", md: "center" }}
+        spacing={2}
+        sx={{ mb: 2.5 }}
+      >
         <Box>
           <SectionHeading id={headingId}>{title}</SectionHeading>
           <Typography color="text.secondary" sx={{ maxWidth: 720 }}>

--- a/src/components/organisms/signal-strip-section.tsx
+++ b/src/components/organisms/signal-strip-section.tsx
@@ -1,0 +1,58 @@
+import { Box, Stack, Typography } from "@mui/material";
+
+import { MonoLabel } from "@/components/atoms";
+
+export type SignalStripItem = {
+  description: string;
+  label: string;
+};
+
+type SignalStripSectionProps = {
+  items: SignalStripItem[];
+};
+
+export function SignalStripSection({ items }: SignalStripSectionProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box
+      component="section"
+      aria-label="Capability signals"
+      sx={{
+        borderBlock: "1px solid",
+        borderColor: "divider",
+        mx: { xs: -2, sm: 0 },
+        px: { xs: 2, sm: 0 },
+        py: 2.5,
+      }}
+    >
+      <Box
+        sx={{
+          display: "grid",
+          gap: 0,
+          gridTemplateColumns: { xs: "1fr", md: `repeat(${items.length}, minmax(0, 1fr))` },
+        }}
+      >
+        {items.map((item, index) => (
+          <Stack
+            key={item.label}
+            spacing={0.75}
+            sx={{
+              borderLeft: { md: index > 0 ? "1px solid" : "none" },
+              borderColor: "divider",
+              px: { xs: 0, md: 2.5 },
+              py: { xs: 1.5, md: 0.5 },
+            }}
+          >
+            <Typography component="h2" variant="h4">
+              {item.label}
+            </Typography>
+            <MonoLabel sx={{ color: "text.secondary" }}>{item.description}</MonoLabel>
+          </Stack>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -4,12 +4,19 @@ const brandTokens = {
   background: "#080A0F",
   surface: "#11151D",
   surfaceRaised: "#171C26",
+  surfaceHover: "#1D2430",
   textPrimary: "#F6F7FB",
   textSecondary: "#A8B0BF",
+  textTertiary: "rgba(246, 247, 251, 0.56)",
   border: "rgba(166, 176, 195, 0.18)",
+  borderStrong: "rgba(166, 176, 195, 0.28)",
   violet: "#9B7CFF",
   violetDark: "#6F55D8",
   violetSoft: "rgba(155, 124, 255, 0.14)",
+  live: "#7BD88F",
+  liveSoft: "rgba(123, 216, 143, 0.16)",
+  curated: "#D4A040",
+  curatedSoft: "rgba(212, 160, 64, 0.13)",
 };
 
 export const theme = createTheme({
@@ -42,20 +49,29 @@ export const theme = createTheme({
     h1: {
       fontFamily: "var(--font-heading), 'Segoe UI', Arial, sans-serif",
       fontWeight: 700,
-      fontSize: "clamp(2rem, 4vw, 3rem)",
-      lineHeight: 1.15,
+      fontSize: "2.35rem",
+      lineHeight: 1.04,
+      "@media (min-width:900px)": {
+        fontSize: "3.5rem",
+      },
     },
     h2: {
       fontFamily: "var(--font-heading), 'Segoe UI', Arial, sans-serif",
       fontWeight: 700,
-      fontSize: "clamp(1.7rem, 3vw, 2.2rem)",
+      fontSize: "1.8rem",
       lineHeight: 1.2,
+      "@media (min-width:900px)": {
+        fontSize: "2.25rem",
+      },
     },
     h3: {
       fontFamily: "var(--font-heading), 'Segoe UI', Arial, sans-serif",
       fontWeight: 700,
-      fontSize: "clamp(1.4rem, 2.4vw, 1.8rem)",
+      fontSize: "1.35rem",
       lineHeight: 1.3,
+      "@media (min-width:900px)": {
+        fontSize: "1.65rem",
+      },
     },
     h4: {
       fontFamily: "var(--font-heading), 'Segoe UI', Arial, sans-serif",
@@ -93,7 +109,10 @@ export const theme = createTheme({
           },
         },
         contained: {
+          backgroundColor: brandTokens.violet,
+          color: "#080A0F",
           "&:hover": {
+            backgroundColor: "#AB94FF",
             boxShadow: "none",
           },
         },
@@ -141,7 +160,25 @@ export const theme = createTheme({
         root: {
           border: `1px solid ${brandTokens.border}`,
           backgroundColor: brandTokens.surface,
+          backgroundImage:
+            "linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0))",
           boxShadow: "none",
+          transition: "background-color 160ms ease, border-color 160ms ease, transform 160ms ease",
+          "&:hover": {
+            backgroundColor: brandTokens.surfaceHover,
+            borderColor: brandTokens.borderStrong,
+            transform: "translateY(-1px)",
+          },
+        },
+      },
+    },
+    MuiCardContent: {
+      styleOverrides: {
+        root: {
+          padding: 20,
+          "&:last-child": {
+            paddingBottom: 20,
+          },
         },
       },
     },
@@ -152,6 +189,8 @@ export const theme = createTheme({
           borderColor: brandTokens.border,
           backgroundColor: brandTokens.surfaceRaised,
           color: brandTokens.textSecondary,
+          fontFamily: "var(--font-code), ui-monospace, SFMono-Regular, Menlo, monospace",
+          fontSize: "0.72rem",
           fontWeight: 600,
         },
         colorPrimary: {


### PR DESCRIPTION
## Summary

Ports the useful Claude redesign visual language into the existing Next.js/MUI implementation without replacing the app architecture or shipping prototype-only claims.

## Changes

- Strengthens the homepage hero into a two-column authority composition with a curated profile signal panel.
- Adds a compact capability signal strip after the hero using truthful software, embedded, robotics, tooling, and proof language.
- Refines MUI theme tokens and component overrides for denser technical cards, crisp borders, compact mono metadata, restrained violet polish, and responsive type without viewport-width font scaling.
- Adds live/curated signal treatment to Working Now and repo freshness surfaces while keeping GitHub optional and allowlisted.
- Updates `docs/current-state.md` to reflect the implemented visual-language port.

## Visual check

- Used the existing local dev server at `http://localhost:3000`.
- Captured desktop at 1440x1100 and mobile at 390x1200 with Microsoft Edge via Playwright.
- Checked the homepage for obvious layout overlap and horizontal overflow.
- Result: no horizontal overflow on desktop or mobile; the mobile header wraps onto a second row without covering content.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `STATIC_EXPORT=true npm run build`

## Stack

This PR is stacked on #62 for issue #7. It keeps the visual port focused on MUI theme/global/component surfaces and does not introduce fake projects, metrics, clients, contact behavior, or a new UI framework.