### PR TITLE
Add Loose Arrow Labs branding and logo

### DIFF
--- a/public/images/glyphs/glyph-bolt.svg
+++ b/public/images/glyphs/glyph-bolt.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="13 2 5 14 12 14 11 22 19 10 12 10 13 2" />
+</svg>

--- a/public/images/glyphs/glyph-chip.svg
+++ b/public/images/glyphs/glyph-chip.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="6" y="6" width="12" height="12" rx="1.5" />
+  <rect x="9" y="9" width="6" height="6" rx="0.75" />
+  <line x1="9" y1="3" x2="9" y2="6" />
+  <line x1="15" y1="3" x2="15" y2="6" />
+  <line x1="9" y1="18" x2="9" y2="21" />
+  <line x1="15" y1="18" x2="15" y2="21" />
+  <line x1="3" y1="9" x2="6" y2="9" />
+  <line x1="3" y1="15" x2="6" y2="15" />
+  <line x1="18" y1="9" x2="21" y2="9" />
+  <line x1="18" y1="15" x2="21" y2="15" />
+</svg>

--- a/public/images/glyphs/glyph-code.svg
+++ b/public/images/glyphs/glyph-code.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="8 7 3 12 8 17" />
+  <polyline points="16 7 21 12 16 17" />
+  <line x1="13" y1="5" x2="11" y2="19" />
+</svg>

--- a/public/images/glyphs/glyph-robot.svg
+++ b/public/images/glyphs/glyph-robot.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 13 L4 7 Q4 5 6 5 L10 5" />
+  <circle cx="10" cy="5" r="1.5" />
+  <path d="M11.5 5 L15 5 Q17 5 17 7 L17 10" />
+  <path d="M17 10 L20 10 Q21 10 21 11 L21 15 Q21 16 20 16 L17 16" />
+  <path d="M17 16 L17 19 Q17 21 15 21 L13 21" />
+  <circle cx="4" cy="13" r="1.25" />
+  <circle cx="13" cy="21" r="1.25" />
+</svg>

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,4 +1,6 @@
 export { ExternalLink } from "./external-link";
+export { LogoLockup } from "./logo-lockup";
+export { LogoMark } from "./logo-mark";
 export { MonoLabel } from "./mono-label";
 export { SectionEyebrow } from "./section-eyebrow";
 export { SectionHeading } from "./section-heading";

--- a/src/components/atoms/logo-lockup.tsx
+++ b/src/components/atoms/logo-lockup.tsx
@@ -1,0 +1,77 @@
+import { Box, Stack, Typography } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material/styles";
+
+import { LogoMark } from "./logo-mark";
+
+const sizeMap = {
+  sm: { mark: 28, name: "0.92rem", labs: "0.52rem", tagline: "0.48rem", gap: 1 },
+  md: { mark: 32, name: "1.05rem", labs: "0.58rem", tagline: "0.52rem", gap: 1.25 },
+  lg: { mark: 48, name: "1.5rem", labs: "0.72rem", tagline: "0.6rem", gap: 1.5 },
+} as const;
+
+type LogoLockupProps = {
+  size?: "sm" | "md" | "lg";
+  showTagline?: boolean;
+  className?: string;
+  sx?: SxProps<Theme>;
+};
+
+export function LogoLockup({ size = "md", showTagline = false, className, sx }: LogoLockupProps) {
+  const t = sizeMap[size];
+
+  return (
+    <Box className={className} sx={{ display: "inline-flex", ...sx }}>
+      <Stack direction="row" spacing={t.gap} sx={{ alignItems: "center" }}>
+        <LogoMark size={t.mark} />
+
+        <Stack spacing={0.25}>
+          <Stack direction="row" spacing={0.75} sx={{ alignItems: "baseline" }}>
+            <Typography
+              component="span"
+              sx={{
+                fontFamily: "var(--font-display)",
+                fontWeight: 700,
+                fontSize: t.name,
+                lineHeight: 1.2,
+                color: "text.primary",
+              }}
+            >
+              Loose Arrow
+            </Typography>
+            <Typography
+              component="span"
+              sx={{
+                color: "#8A7CFF",
+                fontFamily: "var(--font-display)",
+                fontWeight: 700,
+                fontSize: t.labs,
+                letterSpacing: "0.2em",
+                lineHeight: 1.2,
+                textTransform: "uppercase",
+              }}
+            >
+              Labs
+            </Typography>
+          </Stack>
+
+          {showTagline && (
+            <Typography
+              component="span"
+              sx={{
+                color: "text.secondary",
+                fontFamily: "var(--font-code)",
+                fontSize: t.tagline,
+                fontWeight: 500,
+                letterSpacing: "0.18em",
+                lineHeight: 1.4,
+                textTransform: "uppercase",
+              }}
+            >
+              Build cool things.
+            </Typography>
+          )}
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/atoms/logo-mark.tsx
+++ b/src/components/atoms/logo-mark.tsx
@@ -1,0 +1,83 @@
+import { Box } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material/styles";
+
+type LogoMarkProps = {
+  size?: number;
+  className?: string;
+  sx?: SxProps<Theme>;
+};
+
+export function LogoMark({ size = 32, className, sx }: LogoMarkProps) {
+  return (
+    <Box
+      className={className}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: size,
+        height: size,
+        flexShrink: 0,
+        ...sx,
+      }}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 64 64"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        {/* Accent circle behind the arrow */}
+        <circle
+          cx="32"
+          cy="32"
+          r="28"
+          stroke="#8A7CFF"
+          strokeWidth="2"
+          fill="none"
+          opacity="0.85"
+        />
+
+        {/* Speed / brush strokes trailing lower-left */}
+        <line
+          x1="18"
+          y1="50"
+          x2="26"
+          y2="42"
+          stroke="#8A7CFF"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          opacity="0.5"
+        />
+        <line
+          x1="14"
+          y1="46"
+          x2="20"
+          y2="40"
+          stroke="#8A7CFF"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          opacity="0.35"
+        />
+        <line
+          x1="20"
+          y1="54"
+          x2="24"
+          y2="48"
+          stroke="#8A7CFF"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          opacity="0.25"
+        />
+
+        {/* Stylized arrow cursor pointing up-right */}
+        <path
+          d="M22 46 L22 18 L42 32 L32 32 L38 46 L30 40 L28 46 Z"
+          fill="#FFFFFF"
+        />
+      </svg>
+    </Box>
+  );
+}

--- a/src/components/site-shell.tsx
+++ b/src/components/site-shell.tsx
@@ -2,6 +2,7 @@ import { ArrowForward } from "@mui/icons-material";
 import { Box, Button, Container, Stack, Typography } from "@mui/material";
 import type { ReactNode } from "react";
 
+import { LogoMark } from "@/components/atoms/logo-mark";
 import { toInternalHref } from "@/lib/routing";
 import { siteConfig } from "@/lib/site";
 
@@ -59,25 +60,7 @@ export function SiteShell({ children }: SiteShellProps) {
               spacing={1.25}
               sx={{ alignItems: "center", color: "text.primary", textDecoration: "none" }}
             >
-              <Box
-                aria-hidden
-                sx={{
-                  alignItems: "center",
-                  background: "linear-gradient(135deg, #9A85FF, #6B4CFF)",
-                  borderRadius: 1,
-                  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.16)",
-                  color: "#fff",
-                  display: "flex",
-                  fontFamily: "var(--font-code)",
-                  fontSize: "0.72rem",
-                  fontWeight: 800,
-                  height: 28,
-                  justifyContent: "center",
-                  width: 28,
-                }}
-              >
-                AL
-              </Box>
+              <LogoMark size={28} />
               <Stack
                 direction="row"
                 spacing={1}
@@ -85,9 +68,31 @@ export function SiteShell({ children }: SiteShellProps) {
                 flexWrap="wrap"
                 sx={{ alignItems: "baseline" }}
               >
-                <Typography component="span" sx={{ fontSize: "0.92rem", fontWeight: 700 }}>
-                  {siteConfig.ownerName}
-                </Typography>
+                <Stack direction="row" spacing={0.5} sx={{ alignItems: "baseline" }}>
+                  <Typography
+                    component="span"
+                    sx={{
+                      fontFamily: "var(--font-display)",
+                      fontSize: "0.92rem",
+                      fontWeight: 700,
+                    }}
+                  >
+                    Loose Arrow
+                  </Typography>
+                  <Typography
+                    component="span"
+                    sx={{
+                      color: "#8A7CFF",
+                      fontFamily: "var(--font-display)",
+                      fontSize: "0.52rem",
+                      fontWeight: 700,
+                      letterSpacing: "0.2em",
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    Labs
+                  </Typography>
+                </Stack>
                 <Typography
                   component="span"
                   variant="caption"
@@ -192,25 +197,23 @@ export function SiteShell({ children }: SiteShellProps) {
             >
               <Stack spacing={1.5}>
                 <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
-                  <Box
-                    aria-hidden
-                    sx={{
-                      alignItems: "center",
-                      background: "linear-gradient(135deg, #9A85FF, #6B4CFF)",
-                      borderRadius: 1,
-                      color: "#fff",
-                      display: "flex",
-                      fontFamily: "var(--font-code)",
-                      fontSize: "0.72rem",
-                      fontWeight: 800,
-                      height: 24,
-                      justifyContent: "center",
-                      width: 24,
-                    }}
-                  >
-                    AL
-                  </Box>
-                  <Typography sx={{ fontWeight: 700 }}>{siteConfig.ownerName}</Typography>
+                  <LogoMark size={24} />
+                  <Stack direction="row" spacing={0.5} sx={{ alignItems: "baseline" }}>
+                    <Typography sx={{ fontWeight: 700 }}>Loose Arrow</Typography>
+                    <Typography
+                      component="span"
+                      sx={{
+                        color: "#8A7CFF",
+                        fontFamily: "var(--font-display)",
+                        fontSize: "0.58rem",
+                        fontWeight: 700,
+                        letterSpacing: "0.2em",
+                        textTransform: "uppercase",
+                      }}
+                    >
+                      Labs
+                    </Typography>
+                  </Stack>
                 </Stack>
                 <Typography color="text.secondary" variant="body2" sx={{ maxWidth: 320 }}>
                   {siteConfig.studioName} is the studio identity for practical software, embedded


### PR DESCRIPTION
## Summary
- Create `LogoMark` component — inline SVG arrow mark with purple accent circle and speed strokes
- Create `LogoLockup` component — mark + "Loose Arrow" wordmark + "LABS" in purple, with sm/md/lg size variants and optional tagline
- Add 4 glyph SVG icons (`code`, `chip`, `robot`, `bolt`) in `public/images/glyphs/` for brand personality markers
- Replace "AL" monogram in header and footer with the new LogoMark
- Update header/footer text from "Alex Lucero" to "Loose Arrow Labs" branding

## Test plan
- [ ] Header shows arrow logo mark + "Loose Arrow Labs" text
- [ ] Footer shows arrow logo mark + "Loose Arrow Labs" text
- [ ] Build passes with no errors
- [ ] Glyph SVGs load at `/images/glyphs/glyph-*.svg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)