### PR TITLE
Add capability-aligned services

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,80 +73,6 @@ a {
   outline-offset: 2px;
 }
 
-.technology-radio {
-  height: 1px;
-  left: -9999px;
-  opacity: 0;
-  overflow: hidden;
-  width: 1px;
-}
-
-.technology-explorer-card .technology-option {
-  color: #f6f7fb;
-}
-
-.technology-explorer-card .technology-option:hover {
-  background-color: rgba(255, 255, 255, 0.04);
-}
-
-.technology-explorer-card .technology-option::before {
-  align-self: center;
-  border: 1px solid rgba(154, 133, 255, 0.42);
-  border-radius: 999px;
-  content: "";
-  grid-column: 1;
-  height: 0.68rem;
-  justify-self: end;
-  opacity: 0.72;
-  width: 0.68rem;
-}
-
-.technology-explorer-card .technology-option {
-  grid-template-columns: 1fr auto;
-}
-
-.technology-explorer-card .technology-option > * {
-  grid-column: 1;
-}
-
-#device-interfaces-input:checked ~ .technology-explorer-card .technology-option-device-interfaces,
-#ai-workflows-input:checked ~ .technology-explorer-card .technology-option-ai-workflows,
-#application-systems-input:checked
-  ~ .technology-explorer-card
-  .technology-option-application-systems,
-#infrastructure-input:checked ~ .technology-explorer-card .technology-option-infrastructure,
-#fabrication-input:checked ~ .technology-explorer-card .technology-option-fabrication,
-#data-stores-input:checked ~ .technology-explorer-card .technology-option-data-stores {
-  background-color: rgba(138, 124, 255, 0.12);
-  color: #9b7cff;
-}
-
-#device-interfaces-input:checked
-  ~ .technology-explorer-card
-  .technology-option-device-interfaces::before,
-#ai-workflows-input:checked ~ .technology-explorer-card .technology-option-ai-workflows::before,
-#application-systems-input:checked
-  ~ .technology-explorer-card
-  .technology-option-application-systems::before,
-#infrastructure-input:checked ~ .technology-explorer-card .technology-option-infrastructure::before,
-#fabrication-input:checked ~ .technology-explorer-card .technology-option-fabrication::before,
-#data-stores-input:checked ~ .technology-explorer-card .technology-option-data-stores::before {
-  background-color: #9b7cff;
-  box-shadow: 0 0 0 4px rgba(154, 133, 255, 0.16);
-  opacity: 1;
-}
-
-#device-interfaces-input:checked ~ .technology-explorer-card .technology-panel-device-interfaces,
-#ai-workflows-input:checked ~ .technology-explorer-card .technology-panel-ai-workflows,
-#application-systems-input:checked
-  ~ .technology-explorer-card
-  .technology-panel-application-systems,
-#infrastructure-input:checked ~ .technology-explorer-card .technology-panel-infrastructure,
-#fabrication-input:checked ~ .technology-explorer-card .technology-panel-fabrication,
-#data-stores-input:checked ~ .technology-explorer-card .technology-panel-data-stores {
-  display: block;
-}
-
 .capability-radio {
   height: 1px;
   left: -9999px;
@@ -181,6 +107,44 @@ a {
 
 .capability-explorer-card .capability-option > * {
   grid-column: 1;
+}
+
+.capability-mobile-summary {
+  list-style: none;
+}
+
+.capability-mobile-summary::-webkit-details-marker {
+  display: none;
+}
+
+.capability-mobile-summary::before {
+  align-self: center;
+  border: 1px solid rgba(154, 133, 255, 0.42);
+  border-radius: 999px;
+  content: "";
+  grid-column: 1;
+  height: 0.68rem;
+  justify-self: end;
+  opacity: 0.72;
+  width: 0.68rem;
+}
+
+.capability-mobile-summary {
+  grid-template-columns: 1fr auto;
+}
+
+.capability-mobile-summary > * {
+  grid-column: 1;
+}
+
+.capability-mobile-details[open] > .capability-mobile-summary {
+  background-color: rgba(138, 124, 255, 0.12);
+}
+
+.capability-mobile-details[open] > .capability-mobile-summary::before {
+  background-color: #9b7cff;
+  box-shadow: 0 0 0 4px rgba(154, 133, 255, 0.16);
+  opacity: 1;
 }
 
 #digital-product-input:checked ~ .capability-explorer-card .capability-option-digital-product,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -248,7 +248,6 @@ a {
   margin-top: 1.25rem;
   max-height: 36rem;
   opacity: 1;
-  pointer-events: auto;
   transform: translateY(0);
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -147,6 +147,106 @@ a {
   display: block;
 }
 
+.capability-radio {
+  height: 1px;
+  left: -9999px;
+  opacity: 0;
+  overflow: hidden;
+  width: 1px;
+}
+
+.capability-explorer-card .capability-option {
+  color: #f6f7fb;
+}
+
+.capability-explorer-card .capability-option:hover {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.capability-explorer-card .capability-option::before {
+  align-self: center;
+  border: 1px solid rgba(154, 133, 255, 0.42);
+  border-radius: 999px;
+  content: "";
+  grid-column: 1;
+  height: 0.68rem;
+  justify-self: end;
+  opacity: 0.72;
+  width: 0.68rem;
+}
+
+.capability-explorer-card .capability-option {
+  grid-template-columns: 1fr auto;
+}
+
+.capability-explorer-card .capability-option > * {
+  grid-column: 1;
+}
+
+#digital-product-input:checked ~ .capability-explorer-card .capability-option-digital-product,
+#systems-devices-input:checked ~ .capability-explorer-card .capability-option-systems-devices,
+#ai-infrastructure-domain-input:checked
+  ~ .capability-explorer-card
+  .capability-option-ai-infrastructure-domain,
+#advisory-support-input:checked ~ .capability-explorer-card .capability-option-advisory-support,
+#core-capabilities-input:checked ~ .capability-explorer-card .capability-option-core-capabilities {
+  background-color: rgba(138, 124, 255, 0.12);
+  color: #9b7cff;
+}
+
+#digital-product-input:checked
+  ~ .capability-explorer-card
+  .capability-option-digital-product::before,
+#systems-devices-input:checked
+  ~ .capability-explorer-card
+  .capability-option-systems-devices::before,
+#ai-infrastructure-domain-input:checked
+  ~ .capability-explorer-card
+  .capability-option-ai-infrastructure-domain::before,
+#advisory-support-input:checked
+  ~ .capability-explorer-card
+  .capability-option-advisory-support::before,
+#core-capabilities-input:checked
+  ~ .capability-explorer-card
+  .capability-option-core-capabilities::before {
+  background-color: #9b7cff;
+  box-shadow: 0 0 0 4px rgba(154, 133, 255, 0.16);
+  opacity: 1;
+}
+
+#digital-product-input:checked ~ .capability-explorer-card .capability-panel-digital-product,
+#systems-devices-input:checked ~ .capability-explorer-card .capability-panel-systems-devices,
+#ai-infrastructure-domain-input:checked
+  ~ .capability-explorer-card
+  .capability-panel-ai-infrastructure-domain,
+#advisory-support-input:checked ~ .capability-explorer-card .capability-panel-advisory-support,
+#core-capabilities-input:checked ~ .capability-explorer-card .capability-panel-core-capabilities {
+  display: block;
+}
+
+.capability-matrix-item {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.012)),
+    rgba(255, 255, 255, 0.01);
+  transition:
+    border-color 160ms ease,
+    transform 160ms ease,
+    background-color 160ms ease;
+}
+
+.capability-matrix-item:hover,
+.capability-matrix-item:focus-visible {
+  border-color: rgba(154, 133, 255, 0.62);
+  transform: translateY(-2px);
+}
+
+.capability-matrix-item:hover .capability-popout,
+.capability-matrix-item:focus-visible .capability-popout {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0) scale(1.02);
+}
+
 .mdx-content > *:first-child {
   margin-top: 0;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -228,8 +228,10 @@ a {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.012)),
     rgba(255, 255, 255, 0.01);
+  box-shadow: none;
   transition:
     border-color 160ms ease,
+    box-shadow 160ms ease,
     transform 160ms ease,
     background-color 160ms ease;
 }
@@ -237,14 +239,17 @@ a {
 .capability-matrix-item:hover,
 .capability-matrix-item:focus-visible {
   border-color: rgba(154, 133, 255, 0.62);
+  box-shadow: 0 18px 54px rgba(0, 0, 0, 0.28);
   transform: translateY(-2px);
 }
 
 .capability-matrix-item:hover .capability-popout,
 .capability-matrix-item:focus-visible .capability-popout {
+  margin-top: 1.25rem;
+  max-height: 36rem;
   opacity: 1;
   pointer-events: auto;
-  transform: translateY(0) scale(1.02);
+  transform: translateY(0);
 }
 
 .mdx-content > *:first-child {

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -331,96 +331,6 @@ const verticals = [
   { label: "CAD & fabrication", tags: ["3D printing", "bench fixtures", "physical iteration"] },
 ];
 
-const technologySubjects = [
-  {
-    id: "device-interfaces",
-    category: "01. Tech Stack",
-    label: "Embedded & control",
-    description:
-      "Device-side foundations for telemetry, control boundaries, and hardware bring-up.",
-    tools: [
-      "C/C++",
-      "Embedded Linux",
-      "BeagleBone Black",
-      "STM32 / Arduino-class MCUs",
-      "GPIO / I2C / SPI / UART",
-      "systemd",
-    ],
-  },
-  {
-    id: "ai-workflows",
-    category: "01. Tech Stack",
-    label: "AI infrastructure",
-    description: "Local model and retrieval workflows designed around inspectable engineering use.",
-    tools: [
-      "Python",
-      "Local LLM workflows",
-      "RAG pipelines",
-      "Vector / full-text search",
-      "GPU compute",
-      "Agent tooling",
-    ],
-  },
-  {
-    id: "application-systems",
-    category: "01. Tech Stack",
-    label: "Technical software",
-    description:
-      "Application and integration layers for tools, dashboards, APIs, and operational views.",
-    tools: [
-      "C# / .NET",
-      "TypeScript",
-      "React / Next.js",
-      "REST APIs",
-      "SQLite",
-      "Structured logging",
-    ],
-  },
-  {
-    id: "infrastructure",
-    category: "03. Infrastructure",
-    label: "Infrastructure & operations",
-    description: "The operating layer for repeatable development, local services, and lab systems.",
-    tools: [
-      "Linux",
-      "Docker",
-      "Networking / VLAN concepts",
-      "Storage systems",
-      "Observability",
-      "GitHub Actions",
-    ],
-  },
-  {
-    id: "fabrication",
-    category: "04. Physical Systems",
-    label: "Fabrication-aware workflows",
-    description: "Physical iteration and bench validation around the software/hardware boundary.",
-    tools: [
-      "CAD planning",
-      "3D printing",
-      "Bench wiring",
-      "Signal validation",
-      "Test fixtures",
-      "Mechanical packaging",
-    ],
-  },
-  {
-    id: "data-stores",
-    category: "02. Data Stores",
-    label: "Persistence & retrieval",
-    description:
-      "Storage choices for telemetry buffers, engineering notes, search, and operational state.",
-    tools: [
-      "SQLite",
-      "Markdown content",
-      "Vector indexes",
-      "Full-text search",
-      "Structured logs",
-      "Local artifacts",
-    ],
-  },
-];
-
 const engagementSteps = [
   {
     step: "01",
@@ -471,160 +381,13 @@ export default function ServicesPage() {
 
       <ServicesSection headingId="services-list-heading" groups={serviceGroups} />
 
-      <Box component="section" aria-labelledby="technology-heading">
-        <Box
-          component="header"
-          sx={{ borderBottom: "1px solid", borderColor: "divider", mb: 3, pb: 2 }}
-        >
-          <Stack direction="row" spacing={1.5} sx={{ alignItems: "center", mb: 1.5 }}>
-            <MonoLabel>S07</MonoLabel>
-            <Box aria-hidden sx={{ bgcolor: "divider", height: 1, width: 24 }} />
-            <SectionEyebrow sx={{ mb: 0 }}>Technology Stack</SectionEyebrow>
-          </Stack>
-          <SectionHeading id="technology-heading">Technology used across projects</SectionHeading>
-          <Typography color="text.secondary" sx={{ maxWidth: 720, mt: 1 }}>
-            The stack is selected by system constraints, not trend fit. These are the tools and
-            platforms currently shaping Loose Arrow Labs project work.
-          </Typography>
-        </Box>
-
-        {technologySubjects.map((subject, index) => (
-          <Box
-            key={subject.id}
-            id={`${subject.id}-input`}
-            className="technology-radio"
-            component="input"
-            type="radio"
-            name="technology-subject"
-            defaultChecked={index === 0}
-            sx={{ position: "absolute" }}
-          />
-        ))}
-
-        <Card className="technology-explorer-card" sx={{ overflow: "hidden" }}>
-          <Box
-            sx={{
-              display: "grid",
-              gridTemplateColumns: { xs: "1fr", md: "0.9fr 1.6fr" },
-            }}
-          >
-            <Stack
-              component="aside"
-              spacing={1.2}
-              sx={{
-                borderBottom: { xs: "1px solid", md: "none" },
-                borderColor: "divider",
-                borderRight: { md: "1px solid" },
-                p: { xs: 2.5, md: 3.5 },
-              }}
-            >
-              {technologySubjects.map((subject) => (
-                <Box
-                  key={subject.id}
-                  className={`technology-option technology-option-${subject.id}`}
-                  component="label"
-                  htmlFor={`${subject.id}-input`}
-                  sx={{
-                    borderRadius: 1,
-                    cursor: "pointer",
-                    display: "grid",
-                    gap: 0.4,
-                    px: 1.25,
-                    py: 1,
-                    transition: "background-color 160ms ease, color 160ms ease",
-                  }}
-                >
-                  <Typography
-                    component="span"
-                    sx={{
-                      color: "inherit",
-                      fontFamily: "var(--font-display)",
-                      fontSize: { xs: "1rem", md: "1.05rem" },
-                      fontWeight: 700,
-                    }}
-                  >
-                    {subject.label}
-                  </Typography>
-                  <Typography
-                    component="span"
-                    sx={{
-                      color: "text.secondary",
-                      fontFamily: "var(--font-code)",
-                      fontSize: "0.68rem",
-                      letterSpacing: "0.08em",
-                      textTransform: "uppercase",
-                    }}
-                  >
-                    {subject.category}
-                  </Typography>
-                </Box>
-              ))}
-            </Stack>
-
-            <Stack
-              spacing={0}
-              sx={{
-                minHeight: { md: 360 },
-                p: { xs: 2.5, md: 3.5 },
-              }}
-            >
-              {technologySubjects.map((subject) => (
-                <Box
-                  key={subject.id}
-                  className={`technology-panel technology-panel-${subject.id}`}
-                  sx={{
-                    display: "none",
-                  }}
-                >
-                  <SectionEyebrow>{subject.category}</SectionEyebrow>
-                  <SectionHeading component="h3" sx={{ fontSize: "1.8rem", mt: 1 }}>
-                    {subject.label}
-                  </SectionHeading>
-                  <Typography color="text.secondary" sx={{ maxWidth: 620, mb: 3, mt: 1 }}>
-                    {subject.description}
-                  </Typography>
-                  <Box
-                    sx={{
-                      display: "grid",
-                      gap: 1.25,
-                      gridTemplateColumns: {
-                        xs: "1fr",
-                        sm: "repeat(2, minmax(0, 1fr))",
-                        lg: "repeat(3, minmax(0, 1fr))",
-                      },
-                    }}
-                  >
-                    {subject.tools.map((tool) => (
-                      <Box
-                        key={tool}
-                        sx={{
-                          border: "1px solid",
-                          borderColor: "divider",
-                          borderRadius: 1,
-                          background:
-                            "linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.012))",
-                          minHeight: 84,
-                          p: 1.75,
-                        }}
-                      >
-                        <TechTag label={tool} />
-                      </Box>
-                    ))}
-                  </Box>
-                </Box>
-              ))}
-            </Stack>
-          </Box>
-        </Card>
-      </Box>
-
       <Box component="section" aria-labelledby="verticals-heading">
         <Box
           component="header"
           sx={{ borderBottom: "1px solid", borderColor: "divider", mb: 3, pb: 2 }}
         >
           <Stack direction="row" spacing={1.5} sx={{ alignItems: "center", mb: 1.5 }}>
-            <MonoLabel>S08</MonoLabel>
+            <MonoLabel>S07</MonoLabel>
             <Box aria-hidden sx={{ bgcolor: "divider", height: 1, width: 24 }} />
             <SectionEyebrow sx={{ mb: 0 }}>Operating Domains</SectionEyebrow>
           </Stack>
@@ -681,7 +444,7 @@ export default function ServicesPage() {
           sx={{ borderBottom: "1px solid", borderColor: "divider", mb: 3, pb: 2 }}
         >
           <Stack direction="row" spacing={1.5} sx={{ alignItems: "center", mb: 1.5 }}>
-            <MonoLabel>S09</MonoLabel>
+            <MonoLabel>S08</MonoLabel>
             <Box aria-hidden sx={{ bgcolor: "divider", height: 1, width: 24 }} />
             <SectionEyebrow sx={{ mb: 0 }}>Engagement Model</SectionEyebrow>
           </Stack>
@@ -729,15 +492,17 @@ export default function ServicesPage() {
           Bring the constraint, the hardware, the workflow, or the messy integration boundary. The
           first useful output is often a clearer architecture and a validation plan.
         </Typography>
-        <CTAGroup
-          actions={[
-            {
-              href: toInternalHref("/contact"),
-              label: "Start with the problem",
-              variant: "contained",
-            },
-          ]}
-        />
+        <Box sx={{ display: "flex", justifyContent: "center" }}>
+          <CTAGroup
+            actions={[
+              {
+                href: toInternalHref("/contact"),
+                label: "Start with the problem",
+                variant: "contained",
+              },
+            ]}
+          />
+        </Box>
       </Box>
     </Stack>
   );

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 
 import { MonoLabel, SectionEyebrow, SectionHeading, TechTag } from "@/components/atoms";
 import { CTAGroup } from "@/components/molecules";
-import { ServicesSection, type ServiceItem } from "@/components/organisms";
+import { ServicesSection, type ServiceGroup } from "@/components/organisms";
 import { toInternalHref } from "@/lib/routing";
 
 export const dynamic = "force-static";
@@ -14,42 +14,174 @@ export const metadata: Metadata = {
     "Prototype systems engineering, embedded integration, AI infrastructure, technical software, and R&D support from Loose Arrow Labs.",
 };
 
-const serviceItems: ServiceItem[] = [
+const serviceGroups: ServiceGroup[] = [
   {
-    id: "prototype-systems",
-    title: "Prototype systems engineering",
+    id: "digital-product",
+    eyebrow: "01. Product Layer",
+    title: "Digital product",
     description:
-      "Concept-to-proof work for technical systems: architecture, subsystem boundaries, integration plans, risk mapping, and validation artifacts.",
+      "Interfaces, applications, and MVPs for technical products where the software has to explain, operate, or validate a real system.",
+    items: [
+      {
+        id: "mvp-development",
+        title: "MVP development",
+        description:
+          "Small, inspectable first versions that prove the riskiest workflow, integration boundary, or product assumption before the build grows.",
+      },
+      {
+        id: "web-development",
+        title: "Web development",
+        description:
+          "Static-first websites, portfolio systems, technical landing pages, internal tools, dashboards, and content-driven front ends.",
+      },
+      {
+        id: "frontend-development",
+        title: "Front end development",
+        description:
+          "React and Next.js interfaces for technical products, operational workflows, documentation surfaces, and data-heavy views.",
+      },
+      {
+        id: "backend-development",
+        title: "Back end development",
+        description:
+          "APIs, local services, integration layers, background jobs, and application logic that keep technical systems understandable.",
+      },
+      {
+        id: "ui-ux-design",
+        title: "UI/UX design",
+        description:
+          "Clear product flows, interface structure, technical content hierarchy, and usable controls for tools people need to operate.",
+      },
+    ],
   },
   {
-    id: "embedded-telemetry",
-    title: "Embedded systems & telemetry",
+    id: "systems-devices",
+    eyebrow: "02. Device Layer",
+    title: "Systems & devices",
     description:
-      "Embedded Linux services, firmware-adjacent interfaces, sensor acquisition, framed telemetry, local persistence, and field-oriented validation.",
+      "Hardware-aware software, embedded interfaces, telemetry paths, and robotic or IoT systems that need practical integration discipline.",
+    items: [
+      {
+        id: "prototype-systems",
+        title: "Prototype systems engineering",
+        description:
+          "Concept-to-proof work for technical systems: architecture, subsystem boundaries, integration plans, risk mapping, and validation artifacts.",
+      },
+      {
+        id: "embedded-telemetry",
+        title: "Embedded systems & telemetry",
+        description:
+          "Embedded Linux services, firmware-adjacent interfaces, sensor acquisition, framed telemetry, local persistence, and field-oriented validation.",
+      },
+      {
+        id: "firmware-development",
+        title: "Firmware development",
+        description:
+          "Firmware-adjacent development for MCUs and embedded devices: interfaces, protocols, device behavior, and validation notes.",
+      },
+      {
+        id: "iot-development",
+        title: "IoT development",
+        description:
+          "Connected-device prototypes, sensor pipelines, edge services, telemetry transport, and operational visibility for physical systems.",
+      },
+      {
+        id: "ai-iot-systems",
+        title: "AI for IoT systems",
+        description:
+          "AI-assisted analysis, classification, retrieval, and local inference workflows around device data and field telemetry.",
+      },
+      {
+        id: "robotics-automation",
+        title: "Robotics & automation platforms",
+        description:
+          "MCU/Linux runtime separation, actuator and sensor interfaces, simulation modes, observability, and control-system integration.",
+      },
+    ],
   },
   {
-    id: "robotics-automation",
-    title: "Robotics & automation platforms",
+    id: "ai-infrastructure-domain",
+    eyebrow: "03. Operating Layer",
+    title: "AI & infrastructure",
     description:
-      "MCU/Linux runtime separation, actuator and sensor interfaces, simulation modes, observability, and control-system integration.",
+      "The data, deployment, automation, and local infrastructure layer that lets prototypes become repeatable engineering systems.",
+    items: [
+      {
+        id: "ai-infrastructure",
+        title: "AI infrastructure & local inference",
+        description:
+          "GPU/server lab architecture, local model workflows, retrieval systems, agent tooling, and AI-assisted engineering automation.",
+      },
+      {
+        id: "technical-software",
+        title: "Technical software & integrations",
+        description:
+          "Backend services, APIs, engineering dashboards, internal tools, telemetry viewers, and systems that connect hardware to operations.",
+      },
+      {
+        id: "database-modeling",
+        title: "Database modeling",
+        description:
+          "Practical schema design, local persistence, telemetry storage, migration planning, and retrieval models for engineering data.",
+      },
+      {
+        id: "devops-services",
+        title: "DevOps services",
+        description:
+          "Repeatable build, deploy, validation, observability, and automation practices for small technical teams and lab systems.",
+      },
+      {
+        id: "cloud-software-development",
+        title: "Cloud software development",
+        description:
+          "Cloud-hosted services, deployment architecture, storage choices, and integration planning when a system needs managed infrastructure.",
+      },
+      {
+        id: "linux-operations",
+        title: "Linux infrastructure & operations",
+        description:
+          "Networking, Docker, storage, observability, self-hosted services, repeatable deployment, and maintainable engineering environments.",
+      },
+    ],
   },
   {
-    id: "ai-infrastructure",
-    title: "AI infrastructure & local inference",
+    id: "advisory-support",
+    eyebrow: "04. Decision Layer",
+    title: "Advisory & support",
     description:
-      "GPU/server lab architecture, local model workflows, retrieval systems, agent tooling, and AI-assisted engineering automation.",
-  },
-  {
-    id: "technical-software",
-    title: "Technical software & integrations",
-    description:
-      "Backend services, APIs, engineering dashboards, internal tools, telemetry viewers, and systems that connect hardware to operations.",
-  },
-  {
-    id: "linux-operations",
-    title: "Linux infrastructure & operations",
-    description:
-      "Networking, Docker, storage, observability, self-hosted services, repeatable deployment, and maintainable engineering environments.",
+      "Focused technical judgment before, during, and after a build: feasibility, roadmap decisions, handoff, and iteration support.",
+    items: [
+      {
+        id: "rnd-services",
+        title: "R&D services",
+        description:
+          "Focused research, feasibility checks, bench experiments, and technical option mapping for uncertain hardware/software work.",
+      },
+      {
+        id: "iot-consulting-services",
+        title: "IoT consulting services",
+        description:
+          "Practical guidance on device architecture, edge/cloud boundaries, telemetry models, and build-vs-buy choices for IoT systems.",
+      },
+      {
+        id: "tech-advisory",
+        title: "Tech advisory",
+        description:
+          "Decision support for architecture, stack selection, system risk, technical roadmaps, and prototype-to-production tradeoffs.",
+      },
+      {
+        id: "post-production-support",
+        title: "Post-production support",
+        description:
+          "Maintenance, debugging, instrumentation, documentation, and release support after a prototype or system is already in use.",
+      },
+      {
+        id: "dedicated-technical-support",
+        title: "Dedicated technical support",
+        description:
+          "Hands-on builder support for teams that need a technical partner across architecture, implementation, validation, and iteration.",
+      },
+    ],
   },
 ];
 
@@ -200,7 +332,7 @@ export default function ServicesPage() {
         </Box>
       </Box>
 
-      <ServicesSection headingId="services-list-heading" items={serviceItems} />
+      <ServicesSection headingId="services-list-heading" groups={serviceGroups} />
 
       <Box component="section" aria-labelledby="technology-heading">
         <Box

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -27,30 +27,51 @@ const serviceGroups: ServiceGroup[] = [
         title: "MVP development",
         description:
           "Small, inspectable first versions that prove the riskiest workflow, integration boundary, or product assumption before the build grows.",
+        detail:
+          "Useful for early product bets where the important question is whether the workflow, data model, or integration boundary actually holds up.",
+        stack: ["TypeScript", "Next.js", "React", "MUI", "SQLite", "GitHub Actions"],
       },
       {
         id: "web-development",
         title: "Web development",
         description:
           "Static-first websites, portfolio systems, technical landing pages, internal tools, dashboards, and content-driven front ends.",
+        detail:
+          "Best fit for fast, maintainable web surfaces that need authored content, strong information architecture, and clean technical presentation.",
+        stack: ["Next.js", "MDX", "TypeScript", "Material UI", "Static export", "Vercel"],
       },
       {
         id: "frontend-development",
         title: "Front end development",
         description:
           "React and Next.js interfaces for technical products, operational workflows, documentation surfaces, and data-heavy views.",
+        detail:
+          "Interface work focused on clarity, state, interaction flow, and making complex technical systems easier to operate.",
+        stack: ["React", "Next.js", "TypeScript", "MUI", "Forms", "Data views"],
       },
       {
         id: "backend-development",
         title: "Back end development",
         description:
           "APIs, local services, integration layers, background jobs, and application logic that keep technical systems understandable.",
+        detail:
+          "Service-side work for APIs, integrations, automation, and reliable data movement between tools, devices, and users.",
+        stack: ["C# / .NET", "Python", "REST APIs", "SQLite", "Structured logging", "Workers"],
       },
       {
         id: "ui-ux-design",
         title: "UI/UX design",
         description:
           "Clear product flows, interface structure, technical content hierarchy, and usable controls for tools people need to operate.",
+        detail:
+          "Design work for technical interfaces where the goal is usefulness, scanability, and fewer hidden assumptions.",
+        stack: [
+          "Information architecture",
+          "Wireframes",
+          "MUI",
+          "Interaction states",
+          "Design systems",
+        ],
       },
     ],
   },
@@ -66,36 +87,67 @@ const serviceGroups: ServiceGroup[] = [
         title: "Prototype systems engineering",
         description:
           "Concept-to-proof work for technical systems: architecture, subsystem boundaries, integration plans, risk mapping, and validation artifacts.",
+        detail:
+          "Turns a fuzzy technical goal into a small, testable system with clear interfaces, constraints, and next-step evidence.",
+        stack: [
+          "System architecture",
+          "Interface mapping",
+          "Risk registers",
+          "Validation notes",
+          "Git",
+        ],
       },
       {
         id: "embedded-telemetry",
         title: "Embedded systems & telemetry",
         description:
           "Embedded Linux services, firmware-adjacent interfaces, sensor acquisition, framed telemetry, local persistence, and field-oriented validation.",
+        detail:
+          "Device-side data capture and transport work where signal shape, timing, persistence, and field debugging matter.",
+        stack: ["Embedded Linux", "C/C++", "Python", "UART", "I2C / SPI", "SQLite"],
       },
       {
         id: "firmware-development",
         title: "Firmware development",
         description:
           "Firmware-adjacent development for MCUs and embedded devices: interfaces, protocols, device behavior, and validation notes.",
+        detail:
+          "Firmware and firmware-adjacent work around observable device behavior, protocol boundaries, and testable bring-up steps.",
+        stack: ["C/C++", "STM32", "Arduino-class MCUs", "GPIO", "Serial protocols", "Bench tests"],
       },
       {
         id: "iot-development",
         title: "IoT development",
         description:
           "Connected-device prototypes, sensor pipelines, edge services, telemetry transport, and operational visibility for physical systems.",
+        detail:
+          "Edge-to-application workflows for devices that need to report useful data and stay understandable after deployment.",
+        stack: ["Edge services", "MQTT concepts", "REST APIs", "Telemetry", "Docker", "Linux"],
       },
       {
         id: "ai-iot-systems",
         title: "AI for IoT systems",
         description:
           "AI-assisted analysis, classification, retrieval, and local inference workflows around device data and field telemetry.",
+        detail:
+          "AI workflows around sensor streams, device logs, and telemetry archives where interpretability matters more than novelty.",
+        stack: ["Python", "Local LLMs", "RAG", "Vector search", "Telemetry logs", "GPU workflows"],
       },
       {
         id: "robotics-automation",
         title: "Robotics & automation platforms",
         description:
           "MCU/Linux runtime separation, actuator and sensor interfaces, simulation modes, observability, and control-system integration.",
+        detail:
+          "Runtime boundaries and integration work for robots or automation systems that combine physical control with Linux services.",
+        stack: [
+          "MCU + Linux",
+          "Actuators",
+          "Sensors",
+          "Runtime services",
+          "Simulation modes",
+          "Observability",
+        ],
       },
     ],
   },
@@ -111,36 +163,75 @@ const serviceGroups: ServiceGroup[] = [
         title: "AI infrastructure & local inference",
         description:
           "GPU/server lab architecture, local model workflows, retrieval systems, agent tooling, and AI-assisted engineering automation.",
+        detail:
+          "Local and self-hosted AI infrastructure for inspectable workflows, retrieval, experimentation, and engineering automation.",
+        stack: [
+          "Python",
+          "GPU compute",
+          "Local LLMs",
+          "RAG pipelines",
+          "Vector indexes",
+          "Agent tooling",
+        ],
       },
       {
         id: "technical-software",
         title: "Technical software & integrations",
         description:
           "Backend services, APIs, engineering dashboards, internal tools, telemetry viewers, and systems that connect hardware to operations.",
+        detail:
+          "Custom software where the job is connecting real system behavior to useful operational interfaces and automation.",
+        stack: ["TypeScript", "C# / .NET", "Python", "REST APIs", "Dashboards", "Structured logs"],
       },
       {
         id: "database-modeling",
         title: "Database modeling",
         description:
           "Practical schema design, local persistence, telemetry storage, migration planning, and retrieval models for engineering data.",
+        detail:
+          "Data modeling for telemetry, operational state, authored content, and search/retrieval systems that need to remain explainable.",
+        stack: [
+          "SQLite",
+          "Schema design",
+          "Migrations",
+          "Full-text search",
+          "Vector indexes",
+          "Logs",
+        ],
       },
       {
         id: "devops-services",
         title: "DevOps services",
         description:
           "Repeatable build, deploy, validation, observability, and automation practices for small technical teams and lab systems.",
+        detail:
+          "Practical operations setup for builds, validation, deployment, monitoring, and repeatable engineering environments.",
+        stack: [
+          "GitHub Actions",
+          "Docker",
+          "Linux",
+          "CI checks",
+          "Deployment scripts",
+          "Observability",
+        ],
       },
       {
         id: "cloud-software-development",
         title: "Cloud software development",
         description:
           "Cloud-hosted services, deployment architecture, storage choices, and integration planning when a system needs managed infrastructure.",
+        detail:
+          "Cloud architecture and implementation when the system benefits from managed hosting, storage, and deployment boundaries.",
+        stack: ["Cloud hosting", "APIs", "Object storage", "Managed databases", "Docker", "CI/CD"],
       },
       {
         id: "linux-operations",
         title: "Linux infrastructure & operations",
         description:
           "Networking, Docker, storage, observability, self-hosted services, repeatable deployment, and maintainable engineering environments.",
+        detail:
+          "The practical operating layer for lab servers, self-hosted tools, networked systems, and development environments.",
+        stack: ["Linux", "Docker", "Networking", "Storage", "systemd", "Monitoring"],
       },
     ],
   },
@@ -156,30 +247,76 @@ const serviceGroups: ServiceGroup[] = [
         title: "R&D services",
         description:
           "Focused research, feasibility checks, bench experiments, and technical option mapping for uncertain hardware/software work.",
+        detail:
+          "Short-cycle exploration for unknowns that need evidence before they deserve a full implementation effort.",
+        stack: [
+          "Feasibility notes",
+          "Bench tests",
+          "Architecture sketches",
+          "Risk mapping",
+          "Prototype repos",
+        ],
       },
       {
         id: "iot-consulting-services",
         title: "IoT consulting services",
         description:
           "Practical guidance on device architecture, edge/cloud boundaries, telemetry models, and build-vs-buy choices for IoT systems.",
+        detail:
+          "Decision support for teams sorting out device, edge, cloud, telemetry, and operational visibility boundaries.",
+        stack: [
+          "Device architecture",
+          "Edge/cloud split",
+          "Telemetry models",
+          "Security review",
+          "Roadmapping",
+        ],
       },
       {
         id: "tech-advisory",
         title: "Tech advisory",
         description:
           "Decision support for architecture, stack selection, system risk, technical roadmaps, and prototype-to-production tradeoffs.",
+        detail:
+          "Architecture and roadmap review for situations where technical direction, risk, or maintainability needs a second brain.",
+        stack: [
+          "Architecture review",
+          "Stack selection",
+          "Tradeoff analysis",
+          "Roadmaps",
+          "Technical briefs",
+        ],
       },
       {
         id: "post-production-support",
         title: "Post-production support",
         description:
           "Maintenance, debugging, instrumentation, documentation, and release support after a prototype or system is already in use.",
+        detail:
+          "Support after the first version exists: debugging, instrumentation, release notes, handoff, and maintainability work.",
+        stack: [
+          "Debugging",
+          "Instrumentation",
+          "Release notes",
+          "Docs",
+          "Monitoring",
+          "Maintenance",
+        ],
       },
       {
         id: "dedicated-technical-support",
         title: "Dedicated technical support",
         description:
           "Hands-on builder support for teams that need a technical partner across architecture, implementation, validation, and iteration.",
+        detail:
+          "A focused technical partner role for projects that need continuity across discovery, build, validation, and iteration.",
+        stack: [
+          "Architecture",
+          "Implementation",
+          "Validation",
+          "Documentation",
+          "Technical planning",
+        ],
       },
     ],
   },

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -14,7 +14,7 @@ export { ProjectGrid } from "./project-grid";
 export type { ProjectGridItem } from "./project-grid";
 export { SelectedWorkSection } from "./selected-work-section";
 export { ServicesSection } from "./services-section";
-export type { ServiceItem } from "./services-section";
+export type { ServiceGroup, ServiceItem } from "./services-section";
 export { SignalStripSection } from "./signal-strip-section";
 export type { SignalStripItem } from "./signal-strip-section";
 export { ThinkingOutLoudSection } from "./thinking-out-loud-section";

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -191,7 +191,6 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                           maxHeight: "36rem",
                           mt: 1.25,
                           opacity: 1,
-                          pointerEvents: "auto",
                           py: 2.25,
                           transform: "translateY(0)",
                         },

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -189,6 +189,11 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                           py: 2.25,
                           transform: "translateY(0)",
                         },
+                        "&:focus-visible .capability-summary, &:hover .capability-summary": {
+                          maxHeight: 0,
+                          opacity: 0,
+                          overflow: "hidden",
+                        },
                       }}
                     >
                       <Typography
@@ -203,8 +208,14 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                         {item.title}
                       </Typography>
                       <Typography
+                        className="capability-summary"
                         color="text.secondary"
-                        sx={{ fontSize: "0.88rem", lineHeight: 1.58 }}
+                        sx={{
+                          fontSize: "0.88rem",
+                          lineHeight: 1.58,
+                          maxHeight: "8rem",
+                          transition: "max-height 160ms ease, opacity 160ms ease",
+                        }}
                       >
                         {item.description}
                       </Typography>

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -161,6 +161,7 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
 
                 <Box
                   sx={{
+                    alignItems: "start",
                     display: "grid",
                     gap: 1.25,
                     gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
@@ -177,10 +178,17 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                         border: "1px solid",
                         borderColor: "divider",
                         borderRadius: 1,
-                        minHeight: 164,
+                        minHeight: 176,
                         outline: "none",
                         p: 2.25,
-                        position: "relative",
+                        "&:focus-visible .capability-popout, &:hover .capability-popout": {
+                          maxHeight: "36rem",
+                          mt: 1.25,
+                          opacity: 1,
+                          pointerEvents: "auto",
+                          py: 2.25,
+                          transform: "translateY(0)",
+                        },
                       }}
                     >
                       <Typography
@@ -209,14 +217,15 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                           borderColor: "primary.main",
                           borderRadius: 1,
                           boxShadow: "0 24px 80px rgba(0, 0, 0, 0.5)",
-                          inset: -1,
+                          maxHeight: 0,
                           opacity: 0,
-                          p: 2.25,
+                          overflow: "hidden",
+                          px: 2.25,
+                          py: 0,
                           pointerEvents: "none",
-                          position: "absolute",
-                          transform: "translateY(8px) scale(0.98)",
-                          transition: "opacity 160ms ease, transform 160ms ease",
-                          zIndex: 4,
+                          transform: "translateY(8px)",
+                          transition:
+                            "max-height 220ms ease, margin-top 160ms ease, opacity 160ms ease, transform 160ms ease",
                         }}
                       >
                         <SectionEyebrow sx={{ mb: 0.75 }}>Details</SectionEyebrow>

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -240,7 +240,6 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                         }}
                       >
                         <SectionEyebrow sx={{ mb: 0.75 }}>Details</SectionEyebrow>
-                        <Typography sx={{ fontWeight: 700, mb: 1 }}>{item.title}</Typography>
                         <Typography
                           color="text.secondary"
                           sx={{ fontSize: "0.88rem", lineHeight: 1.58, mb: 1.5 }}

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -8,13 +8,36 @@ export type ServiceItem = {
   description: string;
 };
 
-type ServicesSectionProps = {
-  headingId: string;
+export type ServiceGroup = {
+  id: string;
+  eyebrow: string;
+  title: string;
+  description: string;
   items: ServiceItem[];
 };
 
-export function ServicesSection({ headingId, items }: ServicesSectionProps) {
-  if (items.length === 0) {
+type ServicesSectionProps = {
+  headingId: string;
+  groups?: ServiceGroup[];
+  items?: ServiceItem[];
+};
+
+export function ServicesSection({ headingId, groups, items }: ServicesSectionProps) {
+  const renderedGroups =
+    groups ??
+    (items
+      ? [
+          {
+            id: "core-capabilities",
+            eyebrow: "01. Core Capabilities",
+            title: "Primary engineering work",
+            description: "The recurring capability areas behind Loose Arrow Labs project work.",
+            items,
+          },
+        ]
+      : []);
+
+  if (renderedGroups.length === 0) {
     return null;
   }
 
@@ -41,48 +64,99 @@ export function ServicesSection({ headingId, items }: ServicesSectionProps) {
         </Typography>
       </Box>
 
-      <Box
-        sx={{
-          display: "grid",
-          gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" },
-          gap: 0,
-          border: "1px solid",
-          borderColor: "divider",
-          borderRadius: 1,
-          overflow: "hidden",
-        }}
-      >
-        {items.map((item, index) => (
-          <Card
-            key={item.title}
-            id={item.id}
-            sx={{
-              borderRadius: 0,
-              border: "none",
-              borderRight: index < items.length - 1 ? "1px solid" : "none",
-              borderColor: "divider",
-              backgroundColor: "background.paper",
-              backgroundImage: "none",
-              p: 3.5,
-              "&:hover": {
-                backgroundColor: "background.paper",
+      <Card sx={{ overflow: "hidden" }}>
+        <Stack spacing={0}>
+          {renderedGroups.map((group, groupIndex) => (
+            <Box
+              key={group.id}
+              component="section"
+              aria-labelledby={`${group.id}-heading`}
+              sx={{
+                borderBottom: groupIndex < renderedGroups.length - 1 ? "1px solid" : "none",
                 borderColor: "divider",
-                transform: "none",
-              },
-            }}
-          >
-            <MonoLabel sx={{ color: "primary.main", display: "block", mb: 2 }}>
-              {String(index + 1).padStart(2, "0")}
-            </MonoLabel>
-            <SectionHeading component="h3" sx={{ fontSize: "1.375rem", mb: 1.25 }}>
-              {item.title}
-            </SectionHeading>
-            <Typography color="text.secondary" sx={{ fontSize: "0.9rem", lineHeight: 1.555 }}>
-              {item.description}
-            </Typography>
-          </Card>
-        ))}
-      </Box>
+                display: "grid",
+                gridTemplateColumns: { xs: "1fr", lg: "0.86fr 1.7fr" },
+              }}
+            >
+              <Stack
+                spacing={1.5}
+                sx={{
+                  borderBottom: { xs: "1px solid", lg: "none" },
+                  borderColor: "divider",
+                  borderRight: { lg: "1px solid" },
+                  p: { xs: 2.5, md: 3.5 },
+                }}
+              >
+                <MonoLabel sx={{ color: "primary.main" }}>{group.eyebrow}</MonoLabel>
+                <SectionHeading
+                  component="h3"
+                  id={`${group.id}-heading`}
+                  sx={{ fontSize: { xs: "1.45rem", md: "1.7rem" } }}
+                >
+                  {group.title}
+                </SectionHeading>
+                <Typography color="text.secondary" sx={{ fontSize: "0.94rem", lineHeight: 1.6 }}>
+                  {group.description}
+                </Typography>
+              </Stack>
+
+              <Box
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
+                }}
+              >
+                {group.items.map((item, itemIndex) => (
+                  <Box
+                    key={item.title}
+                    id={item.id}
+                    sx={{
+                      borderBottom: {
+                        xs: itemIndex < group.items.length - 1 ? "1px solid" : "none",
+                        md:
+                          itemIndex < group.items.length - (group.items.length % 2 || 2)
+                            ? "1px solid"
+                            : "none",
+                      },
+                      borderColor: "divider",
+                      borderRight: {
+                        xs: "none",
+                        md:
+                          (itemIndex + 1) % 2 !== 0 && itemIndex < group.items.length - 1
+                            ? "1px solid"
+                            : "none",
+                      },
+                      gridColumn: {
+                        md:
+                          itemIndex === group.items.length - 1 && group.items.length % 2 !== 0
+                            ? "1 / -1"
+                            : "auto",
+                      },
+                      minHeight: 150,
+                      p: { xs: 2.5, md: 3 },
+                    }}
+                  >
+                    <Typography
+                      component="h4"
+                      sx={{
+                        fontFamily: "var(--font-display)",
+                        fontSize: "1.06rem",
+                        fontWeight: 700,
+                        mb: 1,
+                      }}
+                    >
+                      {item.title}
+                    </Typography>
+                    <Typography color="text.secondary" sx={{ fontSize: "0.9rem", lineHeight: 1.6 }}>
+                      {item.description}
+                    </Typography>
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+          ))}
+        </Stack>
+      </Card>
     </Box>
   );
 }

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -6,6 +6,8 @@ export type ServiceItem = {
   id?: string;
   title: string;
   description: string;
+  detail?: string;
+  stack?: string[];
 };
 
 export type ServiceGroup = {
@@ -65,97 +67,210 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
       </Box>
 
       <Card sx={{ overflow: "hidden" }}>
-        <Stack spacing={0}>
-          {renderedGroups.map((group, groupIndex) => (
-            <Box
-              key={group.id}
-              component="section"
-              aria-labelledby={`${group.id}-heading`}
-              sx={{
-                borderBottom: groupIndex < renderedGroups.length - 1 ? "1px solid" : "none",
-                borderColor: "divider",
-                display: "grid",
-                gridTemplateColumns: { xs: "1fr", lg: "0.86fr 1.7fr" },
-              }}
-            >
-              <Stack
-                spacing={1.5}
+        {renderedGroups.map((group, index) => (
+          <Box
+            key={group.id}
+            id={`${group.id}-input`}
+            className="capability-radio"
+            component="input"
+            type="radio"
+            name={`${headingId}-capability-group`}
+            defaultChecked={index === 0}
+            sx={{ position: "absolute" }}
+          />
+        ))}
+
+        <Box
+          className="capability-explorer-card"
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", lg: "0.82fr 1.8fr" },
+          }}
+        >
+          <Stack
+            component="aside"
+            spacing={1.2}
+            sx={{
+              borderBottom: { xs: "1px solid", lg: "none" },
+              borderColor: "divider",
+              borderRight: { lg: "1px solid" },
+              p: { xs: 2.5, md: 3.5 },
+            }}
+          >
+            {renderedGroups.map((group) => (
+              <Box
+                key={group.id}
+                className={`capability-option capability-option-${group.id}`}
+                component="label"
+                htmlFor={`${group.id}-input`}
                 sx={{
-                  borderBottom: { xs: "1px solid", lg: "none" },
-                  borderColor: "divider",
-                  borderRight: { lg: "1px solid" },
-                  p: { xs: 2.5, md: 3.5 },
+                  borderRadius: 1,
+                  cursor: "pointer",
+                  display: "grid",
+                  gap: 0.45,
+                  px: 1.25,
+                  py: 1.1,
+                  transition: "background-color 160ms ease, color 160ms ease",
                 }}
               >
-                <MonoLabel sx={{ color: "primary.main" }}>{group.eyebrow}</MonoLabel>
+                <Typography
+                  component="span"
+                  sx={{
+                    color: "inherit",
+                    fontFamily: "var(--font-display)",
+                    fontSize: { xs: "1rem", md: "1.08rem" },
+                    fontWeight: 700,
+                  }}
+                >
+                  {group.title}
+                </Typography>
+                <Typography
+                  component="span"
+                  sx={{
+                    color: "text.secondary",
+                    fontFamily: "var(--font-code)",
+                    fontSize: "0.68rem",
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {group.eyebrow}
+                </Typography>
+              </Box>
+            ))}
+          </Stack>
+
+          <Box sx={{ minHeight: { lg: 520 }, p: { xs: 2.5, md: 3.5 } }}>
+            {renderedGroups.map((group) => (
+              <Box
+                key={group.id}
+                className={`capability-panel capability-panel-${group.id}`}
+                sx={{ display: "none" }}
+              >
+                <SectionEyebrow>{group.eyebrow}</SectionEyebrow>
                 <SectionHeading
                   component="h3"
                   id={`${group.id}-heading`}
-                  sx={{ fontSize: { xs: "1.45rem", md: "1.7rem" } }}
+                  sx={{ fontSize: { xs: "1.55rem", md: "1.9rem" }, mt: 1 }}
                 >
                   {group.title}
                 </SectionHeading>
-                <Typography color="text.secondary" sx={{ fontSize: "0.94rem", lineHeight: 1.6 }}>
+                <Typography color="text.secondary" sx={{ maxWidth: 700, mt: 1.2 }}>
                   {group.description}
                 </Typography>
-              </Stack>
 
-              <Box
-                sx={{
-                  display: "grid",
-                  gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
-                }}
-              >
-                {group.items.map((item, itemIndex) => (
-                  <Box
-                    key={item.title}
-                    id={item.id}
-                    sx={{
-                      borderBottom: {
-                        xs: itemIndex < group.items.length - 1 ? "1px solid" : "none",
-                        md:
-                          itemIndex < group.items.length - (group.items.length % 2 || 2)
-                            ? "1px solid"
-                            : "none",
-                      },
-                      borderColor: "divider",
-                      borderRight: {
-                        xs: "none",
-                        md:
-                          (itemIndex + 1) % 2 !== 0 && itemIndex < group.items.length - 1
-                            ? "1px solid"
-                            : "none",
-                      },
-                      gridColumn: {
-                        md:
-                          itemIndex === group.items.length - 1 && group.items.length % 2 !== 0
-                            ? "1 / -1"
-                            : "auto",
-                      },
-                      minHeight: 150,
-                      p: { xs: 2.5, md: 3 },
-                    }}
-                  >
-                    <Typography
-                      component="h4"
+                <Box
+                  sx={{
+                    display: "grid",
+                    gap: 1.25,
+                    gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
+                    mt: 3,
+                  }}
+                >
+                  {group.items.map((item) => (
+                    <Box
+                      key={item.title}
+                      id={item.id}
+                      className="capability-matrix-item"
+                      tabIndex={0}
                       sx={{
-                        fontFamily: "var(--font-display)",
-                        fontSize: "1.06rem",
-                        fontWeight: 700,
-                        mb: 1,
+                        border: "1px solid",
+                        borderColor: "divider",
+                        borderRadius: 1,
+                        minHeight: 164,
+                        outline: "none",
+                        p: 2.25,
+                        position: "relative",
                       }}
                     >
-                      {item.title}
-                    </Typography>
-                    <Typography color="text.secondary" sx={{ fontSize: "0.9rem", lineHeight: 1.6 }}>
-                      {item.description}
-                    </Typography>
-                  </Box>
-                ))}
+                      <Typography
+                        component="h4"
+                        sx={{
+                          fontFamily: "var(--font-display)",
+                          fontSize: "1.05rem",
+                          fontWeight: 700,
+                          mb: 1,
+                        }}
+                      >
+                        {item.title}
+                      </Typography>
+                      <Typography
+                        color="text.secondary"
+                        sx={{ fontSize: "0.88rem", lineHeight: 1.58 }}
+                      >
+                        {item.description}
+                      </Typography>
+
+                      <Box
+                        className="capability-popout"
+                        sx={{
+                          backgroundColor: "rgba(18, 18, 28, 0.98)",
+                          border: "1px solid",
+                          borderColor: "primary.main",
+                          borderRadius: 1,
+                          boxShadow: "0 24px 80px rgba(0, 0, 0, 0.5)",
+                          inset: -1,
+                          opacity: 0,
+                          p: 2.25,
+                          pointerEvents: "none",
+                          position: "absolute",
+                          transform: "translateY(8px) scale(0.98)",
+                          transition: "opacity 160ms ease, transform 160ms ease",
+                          zIndex: 4,
+                        }}
+                      >
+                        <SectionEyebrow sx={{ mb: 0.75 }}>Details</SectionEyebrow>
+                        <Typography sx={{ fontWeight: 700, mb: 1 }}>{item.title}</Typography>
+                        <Typography
+                          color="text.secondary"
+                          sx={{ fontSize: "0.88rem", lineHeight: 1.58, mb: 1.5 }}
+                        >
+                          {item.detail ?? item.description}
+                        </Typography>
+                        {item.stack && item.stack.length > 0 ? (
+                          <Stack spacing={1}>
+                            <Typography
+                              sx={{
+                                color: "primary.main",
+                                fontFamily: "var(--font-code)",
+                                fontSize: "0.68rem",
+                                fontWeight: 700,
+                                letterSpacing: "0.1em",
+                                textTransform: "uppercase",
+                              }}
+                            >
+                              Tech stack
+                            </Typography>
+                            <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+                              {item.stack.map((tool) => (
+                                <Typography
+                                  key={tool}
+                                  component="span"
+                                  sx={{
+                                    border: "1px solid",
+                                    borderColor: "divider",
+                                    borderRadius: 1,
+                                    color: "text.secondary",
+                                    fontFamily: "var(--font-code)",
+                                    fontSize: "0.68rem",
+                                    px: 0.85,
+                                    py: 0.45,
+                                  }}
+                                >
+                                  {tool}
+                                </Typography>
+                              ))}
+                            </Stack>
+                          </Stack>
+                        ) : null}
+                      </Box>
+                    </Box>
+                  ))}
+                </Box>
               </Box>
-            </Box>
-          ))}
-        </Stack>
+            ))}
+          </Box>
+        </Box>
       </Card>
     </Box>
   );

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -168,7 +168,7 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                     mt: 3,
                   }}
                 >
-                  {group.items.map((item) => (
+                  {group.items.map((item, itemIndex) => (
                     <Box
                       key={item.title}
                       id={item.id}
@@ -178,6 +178,12 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                         border: "1px solid",
                         borderColor: "divider",
                         borderRadius: 1,
+                        gridColumn: {
+                          md:
+                            itemIndex === group.items.length - 1 && group.items.length % 2 !== 0
+                              ? "1 / -1"
+                              : "auto",
+                        },
                         minHeight: 176,
                         outline: "none",
                         p: 2.25,

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -43,6 +43,141 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
     return null;
   }
 
+  const renderCapabilityMatrix = (group: ServiceGroup) => (
+    <Box
+      sx={{
+        alignItems: "start",
+        display: "grid",
+        gap: 1.25,
+        gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
+        mt: 3,
+      }}
+    >
+      {group.items.map((item, itemIndex) => (
+        <Box
+          key={item.title}
+          id={item.id}
+          className="capability-matrix-item"
+          tabIndex={0}
+          sx={{
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: 1,
+            gridColumn: {
+              md:
+                itemIndex === group.items.length - 1 && group.items.length % 2 !== 0
+                  ? "1 / -1"
+                  : "auto",
+            },
+            minHeight: 176,
+            outline: "none",
+            p: 2.25,
+            "&:focus-visible .capability-popout, &:hover .capability-popout": {
+              maxHeight: "36rem",
+              mt: 1.25,
+              opacity: 1,
+              py: 2.25,
+              transform: "translateY(0)",
+            },
+            "&:focus-visible .capability-summary, &:hover .capability-summary": {
+              maxHeight: 0,
+              opacity: 0,
+              overflow: "hidden",
+            },
+          }}
+        >
+          <Typography
+            component="h4"
+            sx={{
+              fontFamily: "var(--font-display)",
+              fontSize: "1.05rem",
+              fontWeight: 700,
+              mb: 1,
+            }}
+          >
+            {item.title}
+          </Typography>
+          <Typography
+            className="capability-summary"
+            color="text.secondary"
+            sx={{
+              fontSize: "0.88rem",
+              lineHeight: 1.58,
+              maxHeight: "8rem",
+              transition: "max-height 160ms ease, opacity 160ms ease",
+            }}
+          >
+            {item.description}
+          </Typography>
+
+          <Box
+            className="capability-popout"
+            sx={{
+              backgroundColor: "rgba(18, 18, 28, 0.98)",
+              border: "1px solid",
+              borderColor: "primary.main",
+              borderRadius: 1,
+              boxShadow: "0 24px 80px rgba(0, 0, 0, 0.5)",
+              maxHeight: 0,
+              opacity: 0,
+              overflow: "hidden",
+              px: 2.25,
+              py: 0,
+              pointerEvents: "none",
+              transform: "translateY(8px)",
+              transition:
+                "max-height 220ms ease, margin-top 160ms ease, opacity 160ms ease, transform 160ms ease",
+            }}
+          >
+            <SectionEyebrow sx={{ mb: 0.75 }}>Details</SectionEyebrow>
+            <Typography
+              color="text.secondary"
+              sx={{ fontSize: "0.88rem", lineHeight: 1.58, mb: 1.5 }}
+            >
+              {item.detail ?? item.description}
+            </Typography>
+            {item.stack && item.stack.length > 0 ? (
+              <Stack spacing={1}>
+                <Typography
+                  sx={{
+                    color: "primary.main",
+                    fontFamily: "var(--font-code)",
+                    fontSize: "0.68rem",
+                    fontWeight: 700,
+                    letterSpacing: "0.1em",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  Tech stack
+                </Typography>
+                <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+                  {item.stack.map((tool) => (
+                    <Typography
+                      key={tool}
+                      component="span"
+                      sx={{
+                        border: "1px solid",
+                        borderColor: "divider",
+                        borderRadius: 1,
+                        color: "text.secondary",
+                        fontFamily: "var(--font-code)",
+                        fontSize: "0.68rem",
+                        px: 0.85,
+                        py: 0.45,
+                      }}
+                    >
+                      {tool}
+                    </Typography>
+                  ))}
+                </Stack>
+              </Stack>
+            ) : null}
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+
   return (
     <Box component="section" aria-labelledby={headingId} sx={{ py: { xs: 2, md: 3 } }}>
       <Box
@@ -67,6 +202,71 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
       </Box>
 
       <Card sx={{ overflow: "hidden" }}>
+        <Stack
+          className="capability-mobile-list"
+          spacing={0}
+          sx={{ display: { xs: "flex", lg: "none" } }}
+        >
+          {renderedGroups.map((group, index) => (
+            <Box
+              key={group.id}
+              className="capability-mobile-details"
+              component="details"
+              open={index === 0}
+              sx={{
+                borderBottom: index < renderedGroups.length - 1 ? "1px solid" : "none",
+                borderColor: "divider",
+              }}
+            >
+              <Box
+                className="capability-mobile-summary"
+                component="summary"
+                sx={{
+                  cursor: "pointer",
+                  display: "grid",
+                  gap: 0.45,
+                  p: 2.5,
+                }}
+              >
+                <Typography
+                  component="span"
+                  sx={{
+                    color: "text.primary",
+                    fontFamily: "var(--font-display)",
+                    fontSize: "1.08rem",
+                    fontWeight: 700,
+                  }}
+                >
+                  {group.title}
+                </Typography>
+                <Typography
+                  component="span"
+                  sx={{
+                    color: "text.secondary",
+                    fontFamily: "var(--font-code)",
+                    fontSize: "0.68rem",
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {group.eyebrow}
+                </Typography>
+              </Box>
+
+              <Box sx={{ borderTop: "1px solid", borderColor: "divider", p: 2.5, pt: 3 }}>
+                <SectionEyebrow>{group.eyebrow}</SectionEyebrow>
+                <SectionHeading component="h3" sx={{ fontSize: "1.5rem", mt: 1 }}>
+                  {group.title}
+                </SectionHeading>
+                <Typography color="text.secondary" sx={{ mt: 1.2 }}>
+                  {group.description}
+                </Typography>
+                {renderCapabilityMatrix(group)}
+              </Box>
+            </Box>
+          ))}
+        </Stack>
+
         {renderedGroups.map((group, index) => (
           <Box
             key={group.id}
@@ -83,7 +283,7 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
         <Box
           className="capability-explorer-card"
           sx={{
-            display: "grid",
+            display: { xs: "none", lg: "grid" },
             gridTemplateColumns: { xs: "1fr", lg: "0.82fr 1.8fr" },
           }}
         >
@@ -159,138 +359,7 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                   {group.description}
                 </Typography>
 
-                <Box
-                  sx={{
-                    alignItems: "start",
-                    display: "grid",
-                    gap: 1.25,
-                    gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
-                    mt: 3,
-                  }}
-                >
-                  {group.items.map((item, itemIndex) => (
-                    <Box
-                      key={item.title}
-                      id={item.id}
-                      className="capability-matrix-item"
-                      tabIndex={0}
-                      sx={{
-                        border: "1px solid",
-                        borderColor: "divider",
-                        borderRadius: 1,
-                        gridColumn: {
-                          md:
-                            itemIndex === group.items.length - 1 && group.items.length % 2 !== 0
-                              ? "1 / -1"
-                              : "auto",
-                        },
-                        minHeight: 176,
-                        outline: "none",
-                        p: 2.25,
-                        "&:focus-visible .capability-popout, &:hover .capability-popout": {
-                          maxHeight: "36rem",
-                          mt: 1.25,
-                          opacity: 1,
-                          py: 2.25,
-                          transform: "translateY(0)",
-                        },
-                        "&:focus-visible .capability-summary, &:hover .capability-summary": {
-                          maxHeight: 0,
-                          opacity: 0,
-                          overflow: "hidden",
-                        },
-                      }}
-                    >
-                      <Typography
-                        component="h4"
-                        sx={{
-                          fontFamily: "var(--font-display)",
-                          fontSize: "1.05rem",
-                          fontWeight: 700,
-                          mb: 1,
-                        }}
-                      >
-                        {item.title}
-                      </Typography>
-                      <Typography
-                        className="capability-summary"
-                        color="text.secondary"
-                        sx={{
-                          fontSize: "0.88rem",
-                          lineHeight: 1.58,
-                          maxHeight: "8rem",
-                          transition: "max-height 160ms ease, opacity 160ms ease",
-                        }}
-                      >
-                        {item.description}
-                      </Typography>
-
-                      <Box
-                        className="capability-popout"
-                        sx={{
-                          backgroundColor: "rgba(18, 18, 28, 0.98)",
-                          border: "1px solid",
-                          borderColor: "primary.main",
-                          borderRadius: 1,
-                          boxShadow: "0 24px 80px rgba(0, 0, 0, 0.5)",
-                          maxHeight: 0,
-                          opacity: 0,
-                          overflow: "hidden",
-                          px: 2.25,
-                          py: 0,
-                          pointerEvents: "none",
-                          transform: "translateY(8px)",
-                          transition:
-                            "max-height 220ms ease, margin-top 160ms ease, opacity 160ms ease, transform 160ms ease",
-                        }}
-                      >
-                        <SectionEyebrow sx={{ mb: 0.75 }}>Details</SectionEyebrow>
-                        <Typography
-                          color="text.secondary"
-                          sx={{ fontSize: "0.88rem", lineHeight: 1.58, mb: 1.5 }}
-                        >
-                          {item.detail ?? item.description}
-                        </Typography>
-                        {item.stack && item.stack.length > 0 ? (
-                          <Stack spacing={1}>
-                            <Typography
-                              sx={{
-                                color: "primary.main",
-                                fontFamily: "var(--font-code)",
-                                fontSize: "0.68rem",
-                                fontWeight: 700,
-                                letterSpacing: "0.1em",
-                                textTransform: "uppercase",
-                              }}
-                            >
-                              Tech stack
-                            </Typography>
-                            <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
-                              {item.stack.map((tool) => (
-                                <Typography
-                                  key={tool}
-                                  component="span"
-                                  sx={{
-                                    border: "1px solid",
-                                    borderColor: "divider",
-                                    borderRadius: 1,
-                                    color: "text.secondary",
-                                    fontFamily: "var(--font-code)",
-                                    fontSize: "0.68rem",
-                                    px: 0.85,
-                                    py: 0.45,
-                                  }}
-                                >
-                                  {tool}
-                                </Typography>
-                              ))}
-                            </Stack>
-                          </Stack>
-                        ) : null}
-                      </Box>
-                    </Box>
-                  ))}
-                </Box>
+                {renderCapabilityMatrix(group)}
               </Box>
             ))}
           </Box>

--- a/src/components/site-shell.tsx
+++ b/src/components/site-shell.tsx
@@ -16,19 +16,45 @@ const navigationLinks = [
 
 const serviceMenuGroups = [
   {
-    heading: "Engineering",
+    heading: "Digital Product",
+    links: [
+      { href: "/services#mvp-development", label: "MVP Development" },
+      { href: "/services#web-development", label: "Web Development" },
+      { href: "/services#frontend-development", label: "Front End Development" },
+      { href: "/services#backend-development", label: "Back End Development" },
+      { href: "/services#ui-ux-design", label: "UI/UX Design" },
+    ],
+  },
+  {
+    heading: "Systems & Devices",
     links: [
       { href: "/services#prototype-systems", label: "Prototype Systems" },
       { href: "/services#embedded-telemetry", label: "Embedded & Telemetry" },
+      { href: "/services#firmware-development", label: "Firmware Development" },
+      { href: "/services#iot-development", label: "IoT Development" },
+      { href: "/services#ai-iot-systems", label: "AI for IoT Systems" },
       { href: "/services#robotics-automation", label: "Robotics & Automation" },
     ],
   },
   {
-    heading: "Infrastructure",
+    heading: "AI & Infrastructure",
     links: [
       { href: "/services#ai-infrastructure", label: "AI Infrastructure" },
       { href: "/services#technical-software", label: "Technical Software" },
+      { href: "/services#database-modeling", label: "Database Modeling" },
+      { href: "/services#devops-services", label: "DevOps Services" },
+      { href: "/services#cloud-software-development", label: "Cloud Software" },
       { href: "/services#linux-operations", label: "Linux Operations" },
+    ],
+  },
+  {
+    heading: "Advisory & Support",
+    links: [
+      { href: "/services#rnd-services", label: "R&D Services" },
+      { href: "/services#iot-consulting-services", label: "IoT Consulting" },
+      { href: "/services#tech-advisory", label: "Tech Advisory" },
+      { href: "/services#post-production-support", label: "Post-Production Support" },
+      { href: "/services#dedicated-technical-support", label: "Dedicated Technical Support" },
     ],
   },
 ];
@@ -146,7 +172,7 @@ export function SiteShell({ children }: SiteShellProps) {
                       "&:focus-within .services-menu, &:hover .services-menu": {
                         opacity: 1,
                         pointerEvents: "auto",
-                        transform: "translate(-50%, 0)",
+                        transform: "translate(0, 0)",
                       },
                     }}
                   >
@@ -172,18 +198,18 @@ export function SiteShell({ children }: SiteShellProps) {
                         borderRadius: 1,
                         boxShadow: "0 22px 70px rgba(0, 0, 0, 0.36)",
                         display: { xs: "none", md: "grid" },
-                        gap: 3,
-                        gridTemplateColumns: "repeat(2, minmax(190px, 1fr))",
-                        left: "50%",
-                        minWidth: 500,
+                        gap: 2.5,
+                        gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
                         opacity: 0,
                         p: 3,
                         pointerEvents: "none",
                         position: "absolute",
+                        right: 0,
                         top: "calc(100% + 12px)",
-                        transform: "translate(-50%, -6px)",
+                        transform: "translate(0, -6px)",
                         transition:
                           "opacity 160ms ease, transform 160ms ease, pointer-events 160ms ease",
+                        width: "min(920px, calc(100vw - 48px))",
                         zIndex: 20,
                         "&::before": {
                           content: '""',


### PR DESCRIPTION
## Summary
- Add capability-aligned services from the provided reference menu to the Services page
- Keep each service framed as truthful founder-led Loose Arrow Labs work
- Organize the Services navbar menu into Digital Product, Systems & Devices, AI & Infrastructure, and Advisory & Support domains
- Replace the jumbled Engineering Capabilities grid with a Technology-style capability explorer on desktop
- Use a compact expandable list for Capabilities on mobile, with each domain expanding to show its description and capability matrix
- Fold service-specific tech-stack content into Capabilities and remove the standalone Technology section from the Services page
- Add hover/focus expansion for capability cards, hide the teaser summary during expansion, and span odd final matrix cards across both columns
- Center the final CTA button
- Preserve the existing ServicesSection flat-item API for the homepage while adding grouped rendering for the Services page

Closes #67

## Validation
- npm run lint
- npx prettier --check src/app/services/page.tsx src/components/organisms/services-section.tsx src/app/globals.css src/components/organisms/index.ts src/components/site-shell.tsx
- npm run build
- Browser checks: confirmed Technology section is removed, mobile Capabilities renders as an expandable list, scrolling reaches Operating Domains, and final CTA button is centered

## Notes
- Full npm run format:check is still failing because unrelated existing files are not Prettier-clean.
- Capability explorer work was prototyped on feature/67-capability-tech-explorer and merged into this branch.