### PR TITLE
Prototype capability technology explorer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -147,6 +147,106 @@ a {
   display: block;
 }
 
+.capability-radio {
+  height: 1px;
+  left: -9999px;
+  opacity: 0;
+  overflow: hidden;
+  width: 1px;
+}
+
+.capability-explorer-card .capability-option {
+  color: #f6f7fb;
+}
+
+.capability-explorer-card .capability-option:hover {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.capability-explorer-card .capability-option::before {
+  align-self: center;
+  border: 1px solid rgba(154, 133, 255, 0.42);
+  border-radius: 999px;
+  content: "";
+  grid-column: 1;
+  height: 0.68rem;
+  justify-self: end;
+  opacity: 0.72;
+  width: 0.68rem;
+}
+
+.capability-explorer-card .capability-option {
+  grid-template-columns: 1fr auto;
+}
+
+.capability-explorer-card .capability-option > * {
+  grid-column: 1;
+}
+
+#digital-product-input:checked ~ .capability-explorer-card .capability-option-digital-product,
+#systems-devices-input:checked ~ .capability-explorer-card .capability-option-systems-devices,
+#ai-infrastructure-domain-input:checked
+  ~ .capability-explorer-card
+  .capability-option-ai-infrastructure-domain,
+#advisory-support-input:checked ~ .capability-explorer-card .capability-option-advisory-support,
+#core-capabilities-input:checked ~ .capability-explorer-card .capability-option-core-capabilities {
+  background-color: rgba(138, 124, 255, 0.12);
+  color: #9b7cff;
+}
+
+#digital-product-input:checked
+  ~ .capability-explorer-card
+  .capability-option-digital-product::before,
+#systems-devices-input:checked
+  ~ .capability-explorer-card
+  .capability-option-systems-devices::before,
+#ai-infrastructure-domain-input:checked
+  ~ .capability-explorer-card
+  .capability-option-ai-infrastructure-domain::before,
+#advisory-support-input:checked
+  ~ .capability-explorer-card
+  .capability-option-advisory-support::before,
+#core-capabilities-input:checked
+  ~ .capability-explorer-card
+  .capability-option-core-capabilities::before {
+  background-color: #9b7cff;
+  box-shadow: 0 0 0 4px rgba(154, 133, 255, 0.16);
+  opacity: 1;
+}
+
+#digital-product-input:checked ~ .capability-explorer-card .capability-panel-digital-product,
+#systems-devices-input:checked ~ .capability-explorer-card .capability-panel-systems-devices,
+#ai-infrastructure-domain-input:checked
+  ~ .capability-explorer-card
+  .capability-panel-ai-infrastructure-domain,
+#advisory-support-input:checked ~ .capability-explorer-card .capability-panel-advisory-support,
+#core-capabilities-input:checked ~ .capability-explorer-card .capability-panel-core-capabilities {
+  display: block;
+}
+
+.capability-matrix-item {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.012)),
+    rgba(255, 255, 255, 0.01);
+  transition:
+    border-color 160ms ease,
+    transform 160ms ease,
+    background-color 160ms ease;
+}
+
+.capability-matrix-item:hover,
+.capability-matrix-item:focus-visible {
+  border-color: rgba(154, 133, 255, 0.62);
+  transform: translateY(-2px);
+}
+
+.capability-matrix-item:hover .capability-popout,
+.capability-matrix-item:focus-visible .capability-popout {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0) scale(1.02);
+}
+
 .mdx-content > *:first-child {
   margin-top: 0;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -228,8 +228,10 @@ a {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.012)),
     rgba(255, 255, 255, 0.01);
+  box-shadow: none;
   transition:
     border-color 160ms ease,
+    box-shadow 160ms ease,
     transform 160ms ease,
     background-color 160ms ease;
 }
@@ -237,14 +239,17 @@ a {
 .capability-matrix-item:hover,
 .capability-matrix-item:focus-visible {
   border-color: rgba(154, 133, 255, 0.62);
+  box-shadow: 0 18px 54px rgba(0, 0, 0, 0.28);
   transform: translateY(-2px);
 }
 
 .capability-matrix-item:hover .capability-popout,
 .capability-matrix-item:focus-visible .capability-popout {
+  margin-top: 1.25rem;
+  max-height: 36rem;
   opacity: 1;
   pointer-events: auto;
-  transform: translateY(0) scale(1.02);
+  transform: translateY(0);
 }
 
 .mdx-content > *:first-child {

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -27,30 +27,51 @@ const serviceGroups: ServiceGroup[] = [
         title: "MVP development",
         description:
           "Small, inspectable first versions that prove the riskiest workflow, integration boundary, or product assumption before the build grows.",
+        detail:
+          "Useful for early product bets where the important question is whether the workflow, data model, or integration boundary actually holds up.",
+        stack: ["TypeScript", "Next.js", "React", "MUI", "SQLite", "GitHub Actions"],
       },
       {
         id: "web-development",
         title: "Web development",
         description:
           "Static-first websites, portfolio systems, technical landing pages, internal tools, dashboards, and content-driven front ends.",
+        detail:
+          "Best fit for fast, maintainable web surfaces that need authored content, strong information architecture, and clean technical presentation.",
+        stack: ["Next.js", "MDX", "TypeScript", "Material UI", "Static export", "Vercel"],
       },
       {
         id: "frontend-development",
         title: "Front end development",
         description:
           "React and Next.js interfaces for technical products, operational workflows, documentation surfaces, and data-heavy views.",
+        detail:
+          "Interface work focused on clarity, state, interaction flow, and making complex technical systems easier to operate.",
+        stack: ["React", "Next.js", "TypeScript", "MUI", "Forms", "Data views"],
       },
       {
         id: "backend-development",
         title: "Back end development",
         description:
           "APIs, local services, integration layers, background jobs, and application logic that keep technical systems understandable.",
+        detail:
+          "Service-side work for APIs, integrations, automation, and reliable data movement between tools, devices, and users.",
+        stack: ["C# / .NET", "Python", "REST APIs", "SQLite", "Structured logging", "Workers"],
       },
       {
         id: "ui-ux-design",
         title: "UI/UX design",
         description:
           "Clear product flows, interface structure, technical content hierarchy, and usable controls for tools people need to operate.",
+        detail:
+          "Design work for technical interfaces where the goal is usefulness, scanability, and fewer hidden assumptions.",
+        stack: [
+          "Information architecture",
+          "Wireframes",
+          "MUI",
+          "Interaction states",
+          "Design systems",
+        ],
       },
     ],
   },
@@ -66,36 +87,67 @@ const serviceGroups: ServiceGroup[] = [
         title: "Prototype systems engineering",
         description:
           "Concept-to-proof work for technical systems: architecture, subsystem boundaries, integration plans, risk mapping, and validation artifacts.",
+        detail:
+          "Turns a fuzzy technical goal into a small, testable system with clear interfaces, constraints, and next-step evidence.",
+        stack: [
+          "System architecture",
+          "Interface mapping",
+          "Risk registers",
+          "Validation notes",
+          "Git",
+        ],
       },
       {
         id: "embedded-telemetry",
         title: "Embedded systems & telemetry",
         description:
           "Embedded Linux services, firmware-adjacent interfaces, sensor acquisition, framed telemetry, local persistence, and field-oriented validation.",
+        detail:
+          "Device-side data capture and transport work where signal shape, timing, persistence, and field debugging matter.",
+        stack: ["Embedded Linux", "C/C++", "Python", "UART", "I2C / SPI", "SQLite"],
       },
       {
         id: "firmware-development",
         title: "Firmware development",
         description:
           "Firmware-adjacent development for MCUs and embedded devices: interfaces, protocols, device behavior, and validation notes.",
+        detail:
+          "Firmware and firmware-adjacent work around observable device behavior, protocol boundaries, and testable bring-up steps.",
+        stack: ["C/C++", "STM32", "Arduino-class MCUs", "GPIO", "Serial protocols", "Bench tests"],
       },
       {
         id: "iot-development",
         title: "IoT development",
         description:
           "Connected-device prototypes, sensor pipelines, edge services, telemetry transport, and operational visibility for physical systems.",
+        detail:
+          "Edge-to-application workflows for devices that need to report useful data and stay understandable after deployment.",
+        stack: ["Edge services", "MQTT concepts", "REST APIs", "Telemetry", "Docker", "Linux"],
       },
       {
         id: "ai-iot-systems",
         title: "AI for IoT systems",
         description:
           "AI-assisted analysis, classification, retrieval, and local inference workflows around device data and field telemetry.",
+        detail:
+          "AI workflows around sensor streams, device logs, and telemetry archives where interpretability matters more than novelty.",
+        stack: ["Python", "Local LLMs", "RAG", "Vector search", "Telemetry logs", "GPU workflows"],
       },
       {
         id: "robotics-automation",
         title: "Robotics & automation platforms",
         description:
           "MCU/Linux runtime separation, actuator and sensor interfaces, simulation modes, observability, and control-system integration.",
+        detail:
+          "Runtime boundaries and integration work for robots or automation systems that combine physical control with Linux services.",
+        stack: [
+          "MCU + Linux",
+          "Actuators",
+          "Sensors",
+          "Runtime services",
+          "Simulation modes",
+          "Observability",
+        ],
       },
     ],
   },
@@ -111,36 +163,75 @@ const serviceGroups: ServiceGroup[] = [
         title: "AI infrastructure & local inference",
         description:
           "GPU/server lab architecture, local model workflows, retrieval systems, agent tooling, and AI-assisted engineering automation.",
+        detail:
+          "Local and self-hosted AI infrastructure for inspectable workflows, retrieval, experimentation, and engineering automation.",
+        stack: [
+          "Python",
+          "GPU compute",
+          "Local LLMs",
+          "RAG pipelines",
+          "Vector indexes",
+          "Agent tooling",
+        ],
       },
       {
         id: "technical-software",
         title: "Technical software & integrations",
         description:
           "Backend services, APIs, engineering dashboards, internal tools, telemetry viewers, and systems that connect hardware to operations.",
+        detail:
+          "Custom software where the job is connecting real system behavior to useful operational interfaces and automation.",
+        stack: ["TypeScript", "C# / .NET", "Python", "REST APIs", "Dashboards", "Structured logs"],
       },
       {
         id: "database-modeling",
         title: "Database modeling",
         description:
           "Practical schema design, local persistence, telemetry storage, migration planning, and retrieval models for engineering data.",
+        detail:
+          "Data modeling for telemetry, operational state, authored content, and search/retrieval systems that need to remain explainable.",
+        stack: [
+          "SQLite",
+          "Schema design",
+          "Migrations",
+          "Full-text search",
+          "Vector indexes",
+          "Logs",
+        ],
       },
       {
         id: "devops-services",
         title: "DevOps services",
         description:
           "Repeatable build, deploy, validation, observability, and automation practices for small technical teams and lab systems.",
+        detail:
+          "Practical operations setup for builds, validation, deployment, monitoring, and repeatable engineering environments.",
+        stack: [
+          "GitHub Actions",
+          "Docker",
+          "Linux",
+          "CI checks",
+          "Deployment scripts",
+          "Observability",
+        ],
       },
       {
         id: "cloud-software-development",
         title: "Cloud software development",
         description:
           "Cloud-hosted services, deployment architecture, storage choices, and integration planning when a system needs managed infrastructure.",
+        detail:
+          "Cloud architecture and implementation when the system benefits from managed hosting, storage, and deployment boundaries.",
+        stack: ["Cloud hosting", "APIs", "Object storage", "Managed databases", "Docker", "CI/CD"],
       },
       {
         id: "linux-operations",
         title: "Linux infrastructure & operations",
         description:
           "Networking, Docker, storage, observability, self-hosted services, repeatable deployment, and maintainable engineering environments.",
+        detail:
+          "The practical operating layer for lab servers, self-hosted tools, networked systems, and development environments.",
+        stack: ["Linux", "Docker", "Networking", "Storage", "systemd", "Monitoring"],
       },
     ],
   },
@@ -156,30 +247,76 @@ const serviceGroups: ServiceGroup[] = [
         title: "R&D services",
         description:
           "Focused research, feasibility checks, bench experiments, and technical option mapping for uncertain hardware/software work.",
+        detail:
+          "Short-cycle exploration for unknowns that need evidence before they deserve a full implementation effort.",
+        stack: [
+          "Feasibility notes",
+          "Bench tests",
+          "Architecture sketches",
+          "Risk mapping",
+          "Prototype repos",
+        ],
       },
       {
         id: "iot-consulting-services",
         title: "IoT consulting services",
         description:
           "Practical guidance on device architecture, edge/cloud boundaries, telemetry models, and build-vs-buy choices for IoT systems.",
+        detail:
+          "Decision support for teams sorting out device, edge, cloud, telemetry, and operational visibility boundaries.",
+        stack: [
+          "Device architecture",
+          "Edge/cloud split",
+          "Telemetry models",
+          "Security review",
+          "Roadmapping",
+        ],
       },
       {
         id: "tech-advisory",
         title: "Tech advisory",
         description:
           "Decision support for architecture, stack selection, system risk, technical roadmaps, and prototype-to-production tradeoffs.",
+        detail:
+          "Architecture and roadmap review for situations where technical direction, risk, or maintainability needs a second brain.",
+        stack: [
+          "Architecture review",
+          "Stack selection",
+          "Tradeoff analysis",
+          "Roadmaps",
+          "Technical briefs",
+        ],
       },
       {
         id: "post-production-support",
         title: "Post-production support",
         description:
           "Maintenance, debugging, instrumentation, documentation, and release support after a prototype or system is already in use.",
+        detail:
+          "Support after the first version exists: debugging, instrumentation, release notes, handoff, and maintainability work.",
+        stack: [
+          "Debugging",
+          "Instrumentation",
+          "Release notes",
+          "Docs",
+          "Monitoring",
+          "Maintenance",
+        ],
       },
       {
         id: "dedicated-technical-support",
         title: "Dedicated technical support",
         description:
           "Hands-on builder support for teams that need a technical partner across architecture, implementation, validation, and iteration.",
+        detail:
+          "A focused technical partner role for projects that need continuity across discovery, build, validation, and iteration.",
+        stack: [
+          "Architecture",
+          "Implementation",
+          "Validation",
+          "Documentation",
+          "Technical planning",
+        ],
       },
     ],
   },

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -189,6 +189,11 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                           py: 2.25,
                           transform: "translateY(0)",
                         },
+                        "&:focus-visible .capability-summary, &:hover .capability-summary": {
+                          maxHeight: 0,
+                          opacity: 0,
+                          overflow: "hidden",
+                        },
                       }}
                     >
                       <Typography
@@ -203,8 +208,14 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                         {item.title}
                       </Typography>
                       <Typography
+                        className="capability-summary"
                         color="text.secondary"
-                        sx={{ fontSize: "0.88rem", lineHeight: 1.58 }}
+                        sx={{
+                          fontSize: "0.88rem",
+                          lineHeight: 1.58,
+                          maxHeight: "8rem",
+                          transition: "max-height 160ms ease, opacity 160ms ease",
+                        }}
                       >
                         {item.description}
                       </Typography>

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -161,6 +161,7 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
 
                 <Box
                   sx={{
+                    alignItems: "start",
                     display: "grid",
                     gap: 1.25,
                     gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
@@ -177,10 +178,17 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                         border: "1px solid",
                         borderColor: "divider",
                         borderRadius: 1,
-                        minHeight: 164,
+                        minHeight: 176,
                         outline: "none",
                         p: 2.25,
-                        position: "relative",
+                        "&:focus-visible .capability-popout, &:hover .capability-popout": {
+                          maxHeight: "36rem",
+                          mt: 1.25,
+                          opacity: 1,
+                          pointerEvents: "auto",
+                          py: 2.25,
+                          transform: "translateY(0)",
+                        },
                       }}
                     >
                       <Typography
@@ -209,14 +217,15 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                           borderColor: "primary.main",
                           borderRadius: 1,
                           boxShadow: "0 24px 80px rgba(0, 0, 0, 0.5)",
-                          inset: -1,
+                          maxHeight: 0,
                           opacity: 0,
-                          p: 2.25,
+                          overflow: "hidden",
+                          px: 2.25,
+                          py: 0,
                           pointerEvents: "none",
-                          position: "absolute",
-                          transform: "translateY(8px) scale(0.98)",
-                          transition: "opacity 160ms ease, transform 160ms ease",
-                          zIndex: 4,
+                          transform: "translateY(8px)",
+                          transition:
+                            "max-height 220ms ease, margin-top 160ms ease, opacity 160ms ease, transform 160ms ease",
                         }}
                       >
                         <SectionEyebrow sx={{ mb: 0.75 }}>Details</SectionEyebrow>

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -240,7 +240,6 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                         }}
                       >
                         <SectionEyebrow sx={{ mb: 0.75 }}>Details</SectionEyebrow>
-                        <Typography sx={{ fontWeight: 700, mb: 1 }}>{item.title}</Typography>
                         <Typography
                           color="text.secondary"
                           sx={{ fontSize: "0.88rem", lineHeight: 1.58, mb: 1.5 }}

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -6,6 +6,8 @@ export type ServiceItem = {
   id?: string;
   title: string;
   description: string;
+  detail?: string;
+  stack?: string[];
 };
 
 export type ServiceGroup = {
@@ -65,97 +67,210 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
       </Box>
 
       <Card sx={{ overflow: "hidden" }}>
-        <Stack spacing={0}>
-          {renderedGroups.map((group, groupIndex) => (
-            <Box
-              key={group.id}
-              component="section"
-              aria-labelledby={`${group.id}-heading`}
-              sx={{
-                borderBottom: groupIndex < renderedGroups.length - 1 ? "1px solid" : "none",
-                borderColor: "divider",
-                display: "grid",
-                gridTemplateColumns: { xs: "1fr", lg: "0.86fr 1.7fr" },
-              }}
-            >
-              <Stack
-                spacing={1.5}
+        {renderedGroups.map((group, index) => (
+          <Box
+            key={group.id}
+            id={`${group.id}-input`}
+            className="capability-radio"
+            component="input"
+            type="radio"
+            name={`${headingId}-capability-group`}
+            defaultChecked={index === 0}
+            sx={{ position: "absolute" }}
+          />
+        ))}
+
+        <Box
+          className="capability-explorer-card"
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", lg: "0.82fr 1.8fr" },
+          }}
+        >
+          <Stack
+            component="aside"
+            spacing={1.2}
+            sx={{
+              borderBottom: { xs: "1px solid", lg: "none" },
+              borderColor: "divider",
+              borderRight: { lg: "1px solid" },
+              p: { xs: 2.5, md: 3.5 },
+            }}
+          >
+            {renderedGroups.map((group) => (
+              <Box
+                key={group.id}
+                className={`capability-option capability-option-${group.id}`}
+                component="label"
+                htmlFor={`${group.id}-input`}
                 sx={{
-                  borderBottom: { xs: "1px solid", lg: "none" },
-                  borderColor: "divider",
-                  borderRight: { lg: "1px solid" },
-                  p: { xs: 2.5, md: 3.5 },
+                  borderRadius: 1,
+                  cursor: "pointer",
+                  display: "grid",
+                  gap: 0.45,
+                  px: 1.25,
+                  py: 1.1,
+                  transition: "background-color 160ms ease, color 160ms ease",
                 }}
               >
-                <MonoLabel sx={{ color: "primary.main" }}>{group.eyebrow}</MonoLabel>
+                <Typography
+                  component="span"
+                  sx={{
+                    color: "inherit",
+                    fontFamily: "var(--font-display)",
+                    fontSize: { xs: "1rem", md: "1.08rem" },
+                    fontWeight: 700,
+                  }}
+                >
+                  {group.title}
+                </Typography>
+                <Typography
+                  component="span"
+                  sx={{
+                    color: "text.secondary",
+                    fontFamily: "var(--font-code)",
+                    fontSize: "0.68rem",
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {group.eyebrow}
+                </Typography>
+              </Box>
+            ))}
+          </Stack>
+
+          <Box sx={{ minHeight: { lg: 520 }, p: { xs: 2.5, md: 3.5 } }}>
+            {renderedGroups.map((group) => (
+              <Box
+                key={group.id}
+                className={`capability-panel capability-panel-${group.id}`}
+                sx={{ display: "none" }}
+              >
+                <SectionEyebrow>{group.eyebrow}</SectionEyebrow>
                 <SectionHeading
                   component="h3"
                   id={`${group.id}-heading`}
-                  sx={{ fontSize: { xs: "1.45rem", md: "1.7rem" } }}
+                  sx={{ fontSize: { xs: "1.55rem", md: "1.9rem" }, mt: 1 }}
                 >
                   {group.title}
                 </SectionHeading>
-                <Typography color="text.secondary" sx={{ fontSize: "0.94rem", lineHeight: 1.6 }}>
+                <Typography color="text.secondary" sx={{ maxWidth: 700, mt: 1.2 }}>
                   {group.description}
                 </Typography>
-              </Stack>
 
-              <Box
-                sx={{
-                  display: "grid",
-                  gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
-                }}
-              >
-                {group.items.map((item, itemIndex) => (
-                  <Box
-                    key={item.title}
-                    id={item.id}
-                    sx={{
-                      borderBottom: {
-                        xs: itemIndex < group.items.length - 1 ? "1px solid" : "none",
-                        md:
-                          itemIndex < group.items.length - (group.items.length % 2 || 2)
-                            ? "1px solid"
-                            : "none",
-                      },
-                      borderColor: "divider",
-                      borderRight: {
-                        xs: "none",
-                        md:
-                          (itemIndex + 1) % 2 !== 0 && itemIndex < group.items.length - 1
-                            ? "1px solid"
-                            : "none",
-                      },
-                      gridColumn: {
-                        md:
-                          itemIndex === group.items.length - 1 && group.items.length % 2 !== 0
-                            ? "1 / -1"
-                            : "auto",
-                      },
-                      minHeight: 150,
-                      p: { xs: 2.5, md: 3 },
-                    }}
-                  >
-                    <Typography
-                      component="h4"
+                <Box
+                  sx={{
+                    display: "grid",
+                    gap: 1.25,
+                    gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
+                    mt: 3,
+                  }}
+                >
+                  {group.items.map((item) => (
+                    <Box
+                      key={item.title}
+                      id={item.id}
+                      className="capability-matrix-item"
+                      tabIndex={0}
                       sx={{
-                        fontFamily: "var(--font-display)",
-                        fontSize: "1.06rem",
-                        fontWeight: 700,
-                        mb: 1,
+                        border: "1px solid",
+                        borderColor: "divider",
+                        borderRadius: 1,
+                        minHeight: 164,
+                        outline: "none",
+                        p: 2.25,
+                        position: "relative",
                       }}
                     >
-                      {item.title}
-                    </Typography>
-                    <Typography color="text.secondary" sx={{ fontSize: "0.9rem", lineHeight: 1.6 }}>
-                      {item.description}
-                    </Typography>
-                  </Box>
-                ))}
+                      <Typography
+                        component="h4"
+                        sx={{
+                          fontFamily: "var(--font-display)",
+                          fontSize: "1.05rem",
+                          fontWeight: 700,
+                          mb: 1,
+                        }}
+                      >
+                        {item.title}
+                      </Typography>
+                      <Typography
+                        color="text.secondary"
+                        sx={{ fontSize: "0.88rem", lineHeight: 1.58 }}
+                      >
+                        {item.description}
+                      </Typography>
+
+                      <Box
+                        className="capability-popout"
+                        sx={{
+                          backgroundColor: "rgba(18, 18, 28, 0.98)",
+                          border: "1px solid",
+                          borderColor: "primary.main",
+                          borderRadius: 1,
+                          boxShadow: "0 24px 80px rgba(0, 0, 0, 0.5)",
+                          inset: -1,
+                          opacity: 0,
+                          p: 2.25,
+                          pointerEvents: "none",
+                          position: "absolute",
+                          transform: "translateY(8px) scale(0.98)",
+                          transition: "opacity 160ms ease, transform 160ms ease",
+                          zIndex: 4,
+                        }}
+                      >
+                        <SectionEyebrow sx={{ mb: 0.75 }}>Details</SectionEyebrow>
+                        <Typography sx={{ fontWeight: 700, mb: 1 }}>{item.title}</Typography>
+                        <Typography
+                          color="text.secondary"
+                          sx={{ fontSize: "0.88rem", lineHeight: 1.58, mb: 1.5 }}
+                        >
+                          {item.detail ?? item.description}
+                        </Typography>
+                        {item.stack && item.stack.length > 0 ? (
+                          <Stack spacing={1}>
+                            <Typography
+                              sx={{
+                                color: "primary.main",
+                                fontFamily: "var(--font-code)",
+                                fontSize: "0.68rem",
+                                fontWeight: 700,
+                                letterSpacing: "0.1em",
+                                textTransform: "uppercase",
+                              }}
+                            >
+                              Tech stack
+                            </Typography>
+                            <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+                              {item.stack.map((tool) => (
+                                <Typography
+                                  key={tool}
+                                  component="span"
+                                  sx={{
+                                    border: "1px solid",
+                                    borderColor: "divider",
+                                    borderRadius: 1,
+                                    color: "text.secondary",
+                                    fontFamily: "var(--font-code)",
+                                    fontSize: "0.68rem",
+                                    px: 0.85,
+                                    py: 0.45,
+                                  }}
+                                >
+                                  {tool}
+                                </Typography>
+                              ))}
+                            </Stack>
+                          </Stack>
+                        ) : null}
+                      </Box>
+                    </Box>
+                  ))}
+                </Box>
               </Box>
-            </Box>
-          ))}
-        </Stack>
+            ))}
+          </Box>
+        </Box>
       </Card>
     </Box>
   );

--- a/src/components/organisms/services-section.tsx
+++ b/src/components/organisms/services-section.tsx
@@ -168,7 +168,7 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                     mt: 3,
                   }}
                 >
-                  {group.items.map((item) => (
+                  {group.items.map((item, itemIndex) => (
                     <Box
                       key={item.title}
                       id={item.id}
@@ -178,6 +178,12 @@ export function ServicesSection({ headingId, groups, items }: ServicesSectionPro
                         border: "1px solid",
                         borderColor: "divider",
                         borderRadius: 1,
+                        gridColumn: {
+                          md:
+                            itemIndex === group.items.length - 1 && group.items.length % 2 !== 0
+                              ? "1 / -1"
+                              : "auto",
+                        },
                         minHeight: 176,
                         outline: "none",
                         p: 2.25,


### PR DESCRIPTION
## Summary
- Prototype a Capabilities-only explorer on top of the service-domain branch
- Keep the existing Technology section in place
- Make the Capabilities list behave like the Technology section: selectable domain list with a populated capability matrix
- Add hover/focus popouts for matrix items with more detail and tech-stack tags
- Fix popout sizing so cards expand with content and tech-stack chips stay readable inside the card
- Hide the initial summary on hover/focus so the expanded detail does not duplicate the short description
- Remove the repeated service title from the hover panel
- Make the final matrix card span both columns when a domain has an odd number of capabilities

## Validation
- npm run lint
- npx prettier --check src/components/organisms/services-section.tsx
- npm run build

## Notes
- This is a child-branch experiment based on feature/67-add-capability-services, not main.
- Browser screenshot/click automation has been intermittently flaky in this session, so validation is mostly build plus DOM checks.